### PR TITLE
[People App] fix(validation): enforce vehicle registration ID to accept only a space as the separator.

### DIFF
--- a/apps/people-app/backend/types.bal
+++ b/apps/people-app/backend/types.bal
@@ -22,7 +22,7 @@ type NewVehicle record {|
     # Registration number of the vehicle
     @constraint:String {
         pattern: {
-            value: re `^(?:[A-Za-z]{2,3}|\d{1,3})[- ]\d{4}$`,
+            value: re `^([A-Za-z]{1,3}|\d{1,3}) \d{4}$`,
             message: "Vehicle registration number should be a valid pattern in Sri Lanka."
         }
     }


### PR DESCRIPTION
## Purpose
> fix(validation): enforce vehicle registration ID to accept only a space as the separator.

## Goals
> To maintain data consistency in the database.

## Approach
> Update the input validation.

## Automation tests
 - Unit tests 
   > Done unit tests for the service layer covering CRUD logic. Code coverage: ~85%
 - Integration tests
   > Integration tested via Postman and test database to verify API behavior.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified the report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment

-  Ballerina 2201.12.7
- MySQL 8.0.41
- Tested via Postman and internal API testing tool
