### PR TITLE
[Visitor App] Add Contact Number and Pass Number Columns to Admin Panel Visitor Tables

### DIFF
--- a/apps/visitor-app/webapp/src/view/admin/panel/activeVisits.tsx
+++ b/apps/visitor-app/webapp/src/view/admin/panel/activeVisits.tsx
@@ -239,6 +239,12 @@ const ActiveVisits = () => {
 
   const columns: GridColDef[] = [
     { field: "name", headerName: "Visitor Name", minWidth: 180, flex: 1.5 },
+    {
+      field: "contactNumber",
+      headerName: "Contact Number",
+      minWidth: 150,
+      flex: 1,
+    },
     { field: "email", headerName: "Visitor Email", minWidth: 200, flex: 1.5 },
     { field: "nicNumber", headerName: "Visitor NIC", minWidth: 150, flex: 1 },
     {
@@ -247,6 +253,7 @@ const ActiveVisits = () => {
       minWidth: 150,
       flex: 1,
     },
+    { field: "passNumber", headerName: "Pass Number", minWidth: 120, flex: 1 },
     { field: "purposeOfVisit", headerName: "Purpose", minWidth: 150, flex: 1 },
     {
       field: "timeOfEntry",

--- a/apps/visitor-app/webapp/src/view/admin/panel/visitHistory.tsx
+++ b/apps/visitor-app/webapp/src/view/admin/panel/visitHistory.tsx
@@ -67,6 +67,12 @@ const VisitHistory = () => {
 
   const columns: GridColDef[] = [
     { field: "name", headerName: "Visitor Name", minWidth: 180, flex: 1.5 },
+    {
+      field: "contactNumber",
+      headerName: "Contact Number",
+      minWidth: 150,
+      flex: 1,
+    },
     { field: "email", headerName: "Visitor Email", minWidth: 200, flex: 1.5 },
     { field: "nicNumber", headerName: "Visitor NIC", minWidth: 150, flex: 1 },
     {
@@ -75,6 +81,7 @@ const VisitHistory = () => {
       minWidth: 150,
       flex: 1,
     },
+    { field: "passNumber", headerName: "Pass Number", minWidth: 120, flex: 1 },
     { field: "purposeOfVisit", headerName: "Purpose", minWidth: 150, flex: 1 },
     {
       field: "timeOfEntry",


### PR DESCRIPTION
This pull request adds new columns to the visitor management tables in the admin panel to improve the visibility of visitor details. Specifically, it introduces columns for contact numbers and pass numbers in both the active visits and visit history views.

**Visitor details enhancements:**

* Added a `contactNumber` column to the `ActiveVisits` table in `activeVisits.tsx` to display visitors' contact numbers.
* Added a `passNumber` column to the `ActiveVisits` table in `activeVisits.tsx` to show the pass number assigned to each visitor.
* Added a `contactNumber` column to the `VisitHistory` table in `visitHistory.tsx` for historical visitor contact information.
* Added a `passNumber` column to the `VisitHistory` table in `visitHistory.tsx` to display pass numbers in visit history records.