### PR TITLE
[People App] Removing x-jwt-assertion header

### DIFF
--- a/apps/people-app/webapp/src/utils/apiService.ts
+++ b/apps/people-app/webapp/src/utils/apiService.ts
@@ -90,7 +90,6 @@ export class APIService {
     APIService._instance.interceptors.request.use(
       (config) => {
         config.headers.set("Authorization", "Bearer " + APIService._idToken);
-        config.headers.set("X-JWT-ASSERTION", APIService._idToken);
 
         const endpoint = config.url || "";
 


### PR DESCRIPTION
## Purpose
> Remove redundant X-JWT-ASSERTION header from API request interceptor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified API request handling by removing an unnecessary header from authentication requests. Authorization mechanism remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->