### PR TITLE
[People App] Use LEFT JOIN for optional unit association in getEmployeeInfoQuery

### DIFF
--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -79,7 +79,7 @@ isolated function getEmployeeInfoQuery(string id) returns sql:ParameterizedQuery
         INNER JOIN team t ON e.team_id = t.id
         INNER JOIN sub_team st ON e.sub_team_id = st.id
         INNER JOIN business_unit bu ON e.business_unit_id = bu.id
-        INNER JOIN unit u ON e.unit_id = u.id
+        LEFT JOIN unit u ON e.unit_id = u.id
     WHERE
         e.id = ${id};`;
 


### PR DESCRIPTION

## Purpose
> Change INNER JOIN to LEFT JOIN for unit in getEmployeeInfoQuery to allow for optional unit association.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed employee information retrieval to now include employees without assigned units, ensuring more complete employee data is displayed in queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->