### PR TITLE
[Visitor App] feat: Add 24-hour format option to Expected Entry Time TimePicker

### DIFF
--- a/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
+++ b/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
@@ -641,6 +641,7 @@ function CreateVisit() {
           <Grid item xs={12} md={4}>
             <TimePicker
               label="Expected Entry Time"
+              ampm={false}
               value={
                 formik.values.visitDate && formik.values.timeOfEntry
                   ? dayjs(


### PR DESCRIPTION
This pull request makes a minor update to the `CreateVisit` panel in the employee section of the visitor app. The change ensures that the `TimePicker` for "Expected Entry Time" uses a 24-hour format instead of AM/PM.

* UI improvement:
  * [`apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx`](diffhunk://#diff-95edfbbc47ab934b70fe81d405ad313cbb1d8d44492bf799a088d181114b644dR644): Set `ampm={false}` in the `TimePicker` component for "Expected Entry Time" to use 24-hour time format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The "Expected Entry Time" picker now displays and accepts times in 24-hour format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->