### PR TITLE
fix(careers-app-v2): set build outDir to 'build' for Docker compatibi…

### DIFF
--- a/apps/careers-app-v2/webapp/vite.config.ts
+++ b/apps/careers-app-v2/webapp/vite.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  build: {
+    outDir: "build",
+  },
   resolve: {
     alias: {
       "@root": resolve(__dirname, "."),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build output directory to "build" to standardize where compiled artifacts are placed, improving artifact organization and simplifying deployment and CI/CD workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->