### PR TITLE
refactor(careers-app-v2): rename REACT_APP_BACKEND_BASE_URL to CAREER…

### DIFF
--- a/apps/careers-app-v2/webapp/public/config.js.local
+++ b/apps/careers-app-v2/webapp/public/config.js.local
@@ -6,5 +6,5 @@ window.config = {
   ASGARDEO_REVOKE_ENDPOINT: "https://api.asgardeo.io/t/<org>/oauth2/revoke",
   AUTH_SIGN_IN_REDIRECT_URL: "http://localhost:3000",
   AUTH_SIGN_OUT_REDIRECT_URL: "http://localhost:3000",
-  REACT_APP_BACKEND_BASE_URL: "http://localhost:9090",
+  CAREERS_BACKEND_BASE_URL: "http://localhost:9090",
 };

--- a/apps/careers-app-v2/webapp/src/config/config.ts
+++ b/apps/careers-app-v2/webapp/src/config/config.ts
@@ -26,7 +26,7 @@ declare global {
       ASGARDEO_REVOKE_ENDPOINT: string;
       AUTH_SIGN_IN_REDIRECT_URL: string;
       AUTH_SIGN_OUT_REDIRECT_URL: string;
-      REACT_APP_BACKEND_BASE_URL: string;
+      CAREERS_BACKEND_BASE_URL: string;
     };
   }
 }
@@ -41,7 +41,7 @@ export const AsgardeoConfig: BaseURLAuthClientConfig = {
 
 export const APP_NAME = window.config?.APP_NAME ?? "WSO2 Careers";
 export const APP_DOMAIN = window.config?.APP_DOMAIN ?? "";
-export const ServiceBaseUrl = window.config?.REACT_APP_BACKEND_BASE_URL ?? "";
+export const ServiceBaseUrl = window.config?.CAREERS_BACKEND_BASE_URL ?? "";
 
 export const AppConfig = {
   serviceUrls: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration property naming for backend service connectivity to align with application naming conventions. No functional changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->