### PR TITLE
[People App] Improve clarity of date picker labels in onboarding form

### DIFF
--- a/apps/people-app/webapp/src/view/employees/employeeOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeeOnboarding/steps/JobInfo.tsx
@@ -1723,7 +1723,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
           <Grid container spacing={3}>
             <Grid item xs={12} sm={6} md={4}>
               <DatePicker
-                label="Last Working Date"
+                label="Final Day in Office"
                 disabled={values.employeeStatus !== EmployeeStatus.Left}
                 value={
                   values.finalDayInOffice
@@ -1748,7 +1748,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
             </Grid>
             <Grid item xs={12} sm={6} md={4}>
               <DatePicker
-                label="Employment End Date"
+                label="Final Day of Employment"
                 disabled={values.employeeStatus !== EmployeeStatus.Left}
                 value={
                   values.finalDayOfEmployment


### PR DESCRIPTION
## Purpose
> This pull request makes minor improvements to the employee onboarding UI by updating the labels of two date fields for clarity.

> UI text updates in `JobInfo.tsx`:

- Changed the label "Last Working Date" to "Final Day in Office" for the `finalDayInOffice` date picker.
- Changed the label "Employment End Date" to "Final Day of Employment" for the `finalDayOfEmployment` date picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated field labels in the Resignation Details section when editing employee records for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->