### PR TITLE
[People App] Inactivate employee relationships and emergency contacts on off-boarding

### DIFF
--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -571,7 +571,8 @@ public isolated function hasLeaverFields(UpdateEmployeeJobInfoPayload payload) r
     || payload.finalDayOfEmployment is string
     || payload.resignationReason is string;
 
-# Inactivate all employee relationships (additional manager roles and emergency contacts) during offboarding.
+# Inactivate the leaving employee's emergency contacts and any additional-manager
+# relationships where the employee is listed as the additional manager for others.
 #
 # + employeeId - Employee ID of the employee who is leaving
 # + actor - User performing the operation

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -580,15 +580,16 @@ public isolated function hasLeaverFields(UpdateEmployeeJobInfoPayload payload) r
 isolated function inactivateEmployeeRelationshipsOnOffboarding(string employeeId, string actor)
     returns error? {
 
-    Employee|error? employeeInfo = getEmployeeInfo(employeeId);
-    if employeeInfo is error {
-        return employeeInfo;
-    }
-    if employeeInfo is () {
+    WorkEmailRow|error workEmailRow =
+        databaseClient->queryRow(getEmployeeWorkEmailQuery(employeeId));
+    if workEmailRow is sql:NoRowsError {
         return ();
     }
+    if workEmailRow is error {
+        return workEmailRow;
+    }
 
-    string employeeEmail = employeeInfo.workEmail;
+    string employeeEmail = workEmailRow.workEmail;
     _ = check databaseClient->execute(inactivateAdditionalManagerRelationshipsQuery(employeeEmail, actor));
     _ = check databaseClient->execute(inactivateEmployeeEmergencyContactsQuery(employeeEmail, actor));
 }

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -571,8 +571,7 @@ public isolated function hasLeaverFields(UpdateEmployeeJobInfoPayload payload) r
     || payload.finalDayOfEmployment is string
     || payload.resignationReason is string;
 
-# Inactivate the leaving employee's emergency contacts and any additional-manager
-# relationships where the employee is listed as the additional manager for others.
+# Inactivate any additional-manager relationships where the employee is listed as the additional manager for others.
 #
 # + employeeId - Employee ID of the employee who is leaving
 # + actor - User performing the operation
@@ -591,7 +590,6 @@ isolated function inactivateEmployeeRelationshipsOnOffboarding(string employeeId
 
     string employeeEmail = workEmailRow.workEmail;
     _ = check databaseClient->execute(inactivateAdditionalManagerRelationshipsQuery(employeeEmail, actor));
-    _ = check databaseClient->execute(inactivateEmployeeEmergencyContactsQuery(employeeEmail, actor));
 }
 
 # Sync the resignation table row for an employee based on the job-info update payload.

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -339,7 +339,7 @@ public isolated function addEmployee(CreateEmployeePayload payload, string creat
 public isolated function deleteEmployeeById(string employeeId) returns error? {
     retry transaction {
         EmployeeDeleteIds ids = check databaseClient->queryRow(
-            `SELECT id, personal_info_id FROM employee WHERE employee_id = ${employeeId}`);
+            `SELECT id, personal_info_id as personalInfoId FROM employee WHERE employee_id = ${employeeId}`);
         int employeePkId = ids.id;
         int personalInfoId = ids.personalInfoId;
         _ = check databaseClient->execute(deleteEmployeeAdditionalManagersQuery(employeeId));

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -571,6 +571,27 @@ public isolated function hasLeaverFields(UpdateEmployeeJobInfoPayload payload) r
     || payload.finalDayOfEmployment is string
     || payload.resignationReason is string;
 
+# Inactivate all employee relationships (additional manager roles and emergency contacts) during offboarding.
+#
+# + employeeId - Employee ID of the employee who is leaving
+# + actor - User performing the operation
+# + return - Nil or error
+isolated function inactivateEmployeeRelationshipsOnOffboarding(string employeeId, string actor)
+    returns error? {
+
+    Employee|error? employeeInfo = getEmployeeInfo(employeeId);
+    if employeeInfo is error {
+        return employeeInfo;
+    }
+    if employeeInfo is () {
+        return ();
+    }
+
+    string employeeEmail = employeeInfo.workEmail;
+    _ = check databaseClient->execute(inactivateAdditionalManagerRelationshipsQuery(employeeEmail, actor));
+    _ = check databaseClient->execute(inactivateEmployeeEmergencyContactsQuery(employeeEmail, actor));
+}
+
 # Sync the resignation table row for an employee based on the job-info update payload.
 # Retains any existing resignation record when the employee is reactivated, so historical details are preserved.
 #
@@ -583,6 +604,7 @@ isolated function syncResignationRecord(string employeeId, UpdateEmployeeJobInfo
 
     if hasLeaverFields(payload) {
         _ = check databaseClient->execute(upsertResignationQuery(employeeId, payload, updatedBy));
+        check inactivateEmployeeRelationshipsOnOffboarding(employeeId, updatedBy);
     }
 }
 

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -56,6 +56,13 @@ isolated function getEmployeeIdQuery(int id) returns sql:ParameterizedQuery =>
 isolated function getEmployeeIdByEpfQuery(string epf) returns sql:ParameterizedQuery =>
     `SELECT employee_id FROM employee WHERE epf = ${epf} LIMIT 1;`;
 
+# Fetch employee work email by employee ID.
+#
+# + employeeId - Employee ID
+# + return - Query to get employee work email
+isolated function getEmployeeWorkEmailQuery(string employeeId) returns sql:ParameterizedQuery =>
+    `SELECT work_email FROM employee WHERE employee_id = ${employeeId};`;
+
 # Fetch employee detailed information.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1111,7 +1111,7 @@ isolated function deleteEmergencyContactQuery(string employeeId, string mobile, 
         AND piec.mobile = ${mobile}
         AND piec.is_active = 1;`;
 
-# Inactivate all emergency contacts for the given employee email.
+# Inactivate all emergency contacts belonging to the given employee.
 #
 # + employeeEmail - Work email of the employee who is leaving
 # + actor - User performing the operation
@@ -1123,7 +1123,7 @@ isolated function inactivateEmployeeEmergencyContactsQuery(string employeeEmail,
      SET piec.is_active = 0,
          piec.updated_by = ${actor},
          piec.updated_on = CURRENT_TIMESTAMP(6)
-     WHERE LOWER(e.work_email) = LOWER(${employeeEmail})
+     WHERE e.work_email = ${employeeEmail}
        AND piec.is_active = 1;`;
 
 # Update employee job information query.
@@ -1360,9 +1360,10 @@ isolated function deleteAdditionalManagerQuery(string employeeId, string email, 
         AND LOWER(eam.additional_manager_email) = LOWER(${email})
         AND eam.is_active = 1;`;
 
-# Inactivate all additional manager relationships where the given email is the additional manager.
+# Inactivate all additional-manager relationships where the leaving
+# employee's email is recorded as the additional manager for other employees.
 #
-# + managerEmail - Email of the manager who is leaving
+# + managerEmail - Work email of the employee who is leaving
 # + actor - User performing the operation
 # + return - Parameterized query
 isolated function inactivateAdditionalManagerRelationshipsQuery(string managerEmail, string actor)

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1118,21 +1118,6 @@ isolated function deleteEmergencyContactQuery(string employeeId, string mobile, 
         AND piec.mobile = ${mobile}
         AND piec.is_active = 1;`;
 
-# Inactivate all emergency contacts belonging to the given employee.
-#
-# + employeeEmail - Work email of the employee who is leaving
-# + actor - User performing the operation
-# + return - Parameterized query
-isolated function inactivateEmployeeEmergencyContactsQuery(string employeeEmail, string actor)
-    returns sql:ParameterizedQuery =>
-    `UPDATE personal_info_emergency_contacts piec
-     INNER JOIN employee e ON e.personal_info_id = piec.personal_info_id
-     SET piec.is_active = 0,
-         piec.updated_by = ${actor},
-         piec.updated_on = CURRENT_TIMESTAMP(6)
-     WHERE e.work_email = ${employeeEmail}
-       AND piec.is_active = 1;`;
-
 # Update employee job information query.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1111,6 +1111,21 @@ isolated function deleteEmergencyContactQuery(string employeeId, string mobile, 
         AND piec.mobile = ${mobile}
         AND piec.is_active = 1;`;
 
+# Inactivate all emergency contacts for the given employee email.
+#
+# + employeeEmail - Work email of the employee who is leaving
+# + actor - User performing the operation
+# + return - Parameterized query
+isolated function inactivateEmployeeEmergencyContactsQuery(string employeeEmail, string actor)
+    returns sql:ParameterizedQuery =>
+    `UPDATE personal_info_emergency_contacts piec
+     INNER JOIN employee e ON e.personal_info_id = piec.personal_info_id
+     SET piec.is_active = 0,
+         piec.updated_by = ${actor},
+         piec.updated_on = CURRENT_TIMESTAMP(6)
+     WHERE LOWER(e.work_email) = LOWER(${employeeEmail})
+       AND piec.is_active = 1;`;
+
 # Update employee job information query.
 #
 # + employeeId - Employee ID
@@ -1344,6 +1359,20 @@ isolated function deleteAdditionalManagerQuery(string employeeId, string email, 
       WHERE e.employee_id = ${employeeId}
         AND LOWER(eam.additional_manager_email) = LOWER(${email})
         AND eam.is_active = 1;`;
+
+# Inactivate all additional manager relationships where the given email is the additional manager.
+#
+# + managerEmail - Email of the manager who is leaving
+# + actor - User performing the operation
+# + return - Parameterized query
+isolated function inactivateAdditionalManagerRelationshipsQuery(string managerEmail, string actor)
+    returns sql:ParameterizedQuery =>
+    `UPDATE employee_additional_managers eam
+     SET eam.is_active = 0,
+         eam.updated_by = ${actor},
+         eam.updated_on = CURRENT_TIMESTAMP(6)
+     WHERE LOWER(eam.additional_manager_email) = LOWER(${managerEmail})
+       AND eam.is_active = 1;`;
 
 # Build query to fetch vehicles.
 #

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -669,6 +669,13 @@ type EmployeeNameRow record {|
     string fullName;
 |};
 
+# [Database] Work email row mapping for employee lookups.
+type WorkEmailRow record {|
+    # Work email of the employee
+    @sql:Column {name: "work_email"}
+    string workEmail;
+|};
+
 # Additional manager email row mapping.
 public type AdditionalManagerEmailRow record {|
     # Additional manager email


### PR DESCRIPTION
This pull request adds functionality to inactivate all employee relationships—specifically, additional manager roles and emergency contacts—when an employee is offboarded. This ensures that when an employee leaves, their related records are properly updated for data integrity and compliance. The main changes include new database queries and logic integration during the resignation process.

**Offboarding automation:**
* Added the `inactivateEmployeeRelationshipsOnOffboarding` function to inactivate all additional manager and emergency contact relationships for an employee during offboarding. This function is now called as part of the resignation record synchronization process.

**Database query enhancements:**
* Introduced the `inactivateEmployeeEmergencyContactsQuery` function to bulk inactivate all emergency contacts for a given employee's work email, updating audit fields accordingly.
* Added the `inactivateAdditionalManagerRelationshipsQuery` function to bulk inactivate all additional manager relationships where the given email is the additional manager, also updating audit fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offboarding now inactivates emergency-contact and additional-manager relationships (preserving historical records) instead of deleting them.
  * Resignation processing now triggers relationship inactivation based on the employee’s work email and safely handles missing records.

* **Bug Fixes**
  * Employee lookups during resignation now correctly map returned email fields for downstream processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/people-ops-suite/pull/272)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->