### PR TITLE
Visitor App: Refactor API interceptor and clean up .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,16 +32,3 @@ Config.toml
 .devcontainer.json
 .env
 node_modules
-
-apps/leave-app/.claude/settings.local.json
-apps/leave-app/skills.md
-apps/leave-app/backend/Dependencies.toml
-apps/leave-app/webapp/.claude/settings.local.json
-apps/visitor-app/backend/Dependencies.toml
-apps/visitor-app/backend/Dependencies.toml
-apps/visitor-app/backend/Dependencies.toml
-apps/visitor-app/schedular/CLAUDE.md
-apps/visitor-app/schedular/Dependencies.toml
-apps/visitor-app/webapp/src/react-app-env.d.ts
-apps/visitor-app/schedular/.claude/settings.local.json
-apps/visitor-app/backend/Dependencies.toml

--- a/apps/visitor-app/webapp/src/utils/apiService.ts
+++ b/apps/visitor-app/webapp/src/utils/apiService.ts
@@ -90,7 +90,6 @@ export class APIService {
     APIService._instance.interceptors.request.use(
       (config) => {
         config.headers.set("Authorization", "Bearer " + APIService._idToken);
-        config.headers.set("x-jwt-assertion", APIService._idToken);
 
         const endpoint = config.url || "";
 


### PR DESCRIPTION
This pull request makes a minor update to the `APIService` class by removing the setting of the `x-jwt-assertion` header from outgoing API requests. This simplifies the request headers and may be part of an effort to standardize authentication headers.

- Removed the line that set the `x-jwt-assertion` header in the `APIService` request interceptor in `apiService.ts`.