### PR TITLE
Leave app: Refactor recipient retrieval and simplify leave submission alert

### DIFF
--- a/apps/leave-app/backend/utils.bal
+++ b/apps/leave-app/backend/utils.bal
@@ -430,28 +430,16 @@ public isolated function getNumberOfDaysFromLeaveDays(LeaveDay[] leaveDays) retu
 }
 
 # Retrieves the private email recipients for a given user.
+# Private comments are visible only to the applicant and their lead.
 #
 # + email - The email of the user for whom private recipients are to be determined
-# + userAddedRecipients - A list of additional recipients added by the user
+# + userAddedRecipients - Unused for private comments
 # + token - The authorization token to retrieve user details
 # + return - A readonly array of private email recipients or an error if the operation fails
 public isolated function getPrivateRecipientsForUser(string email, string[] userAddedRecipients, string token)
     returns readonly & string[]|error {
-    map<true> recipientMap = {
-        [email]: true
-    };
     readonly & Employee employee = check employee:getEmployee(email);
-    recipientMap[<string>employee.leadEmail] = true;
-    foreach string recipient in userAddedRecipients {
-        recipientMap[recipient] = true;
-    }
-    foreach string defaultRecipient in defaultRecipients {
-        if recipientMap.hasKey(defaultRecipient) {
-            _ = recipientMap.remove(defaultRecipient);
-        }
-    }
-
-    return recipientMap.keys().cloneReadOnly();
+    return [email, <string>employee.leadEmail].cloneReadOnly();
 }
 
 # Get UTC date from a string in ISO 8601 format. This date will be timezone independent.

--- a/apps/leave-app/backend/utils.bal
+++ b/apps/leave-app/backend/utils.bal
@@ -430,16 +430,28 @@ public isolated function getNumberOfDaysFromLeaveDays(LeaveDay[] leaveDays) retu
 }
 
 # Retrieves the private email recipients for a given user.
-# Private comments are visible only to the applicant and their lead.
 #
 # + email - The email of the user for whom private recipients are to be determined
-# + userAddedRecipients - Unused for private comments
+# + userAddedRecipients - A list of additional recipients added by the user
 # + token - The authorization token to retrieve user details
 # + return - A readonly array of private email recipients or an error if the operation fails
 public isolated function getPrivateRecipientsForUser(string email, string[] userAddedRecipients, string token)
     returns readonly & string[]|error {
+    map<true> recipientMap = {
+        [email]: true
+    };
     readonly & Employee employee = check employee:getEmployee(email);
-    return [email, <string>employee.leadEmail].cloneReadOnly();
+    recipientMap[<string>employee.leadEmail] = true;
+    foreach string recipient in userAddedRecipients {
+        recipientMap[recipient] = true;
+    }
+    foreach string defaultRecipient in defaultRecipients {
+        if recipientMap.hasKey(defaultRecipient) {
+            _ = recipientMap.remove(defaultRecipient);
+        }
+    }
+
+    return recipientMap.keys().cloneReadOnly();
 }
 
 # Get UTC date from a string in ISO 8601 format. This date will be timezone independent.

--- a/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
+++ b/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
@@ -221,7 +221,7 @@ export default function GeneralLeave() {
 
     showConfirmation(
       "Do you want to submit this leave?",
-      `This will submit a ${leaveLabel} request for ${workingDays} working day${workingDays !== 1 ? "s" : ""} (${dateRange}, ${portionLabel}). This action cannot be undone.`,
+      `This will submit a ${leaveLabel} request for ${workingDays} working day${workingDays !== 1 ? "s" : ""} (${dateRange}, ${portionLabel}).`,
       ConfirmationType.send,
       () => executeSubmit(periodType, isMorningLeave),
       "Yes",


### PR DESCRIPTION
This pull request introduces a small but important change to the leave application system, specifically clarifying and simplifying the handling of private comment recipients and improving user communication when submitting leave requests.

Recipient determination logic simplification:

* The `getPrivateRecipientsForUser` function in `utils.bal` now only includes the applicant and their lead as recipients for private comments, removing logic related to user-added and default recipients for increased clarity and correctness.

User interface improvement:

* The leave submission confirmation message in `GeneralLeave.tsx` has been simplified by removing the phrase "This action cannot be undone," making the prompt more concise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified the confirmation message displayed when submitting leave requests.
  * Refined private recipient selection for leave request notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->