### PR TITLE
Leave app: Refactor recipient retrieval and improve confirmation messages

### DIFF
--- a/apps/leave-app/backend/utils.bal
+++ b/apps/leave-app/backend/utils.bal
@@ -430,28 +430,16 @@ public isolated function getNumberOfDaysFromLeaveDays(LeaveDay[] leaveDays) retu
 }
 
 # Retrieves the private email recipients for a given user.
+# Private comments are visible only to the applicant and their lead.
 #
 # + email - The email of the user for whom private recipients are to be determined
-# + userAddedRecipients - A list of additional recipients added by the user
+# + userAddedRecipients - Unused for private comments
 # + token - The authorization token to retrieve user details
 # + return - A readonly array of private email recipients or an error if the operation fails
 public isolated function getPrivateRecipientsForUser(string email, string[] userAddedRecipients, string token)
     returns readonly & string[]|error {
-    map<true> recipientMap = {
-        [email]: true
-    };
     readonly & Employee employee = check employee:getEmployee(email);
-    recipientMap[<string>employee.leadEmail] = true;
-    foreach string recipient in userAddedRecipients {
-        recipientMap[recipient] = true;
-    }
-    foreach string defaultRecipient in defaultRecipients {
-        if recipientMap.hasKey(defaultRecipient) {
-            _ = recipientMap.remove(defaultRecipient);
-        }
-    }
-
-    return recipientMap.keys().cloneReadOnly();
+    return [email, <string>employee.leadEmail].cloneReadOnly();
 }
 
 # Get UTC date from a string in ISO 8601 format. This date will be timezone independent.

--- a/apps/leave-app/backend/utils.bal
+++ b/apps/leave-app/backend/utils.bal
@@ -430,16 +430,28 @@ public isolated function getNumberOfDaysFromLeaveDays(LeaveDay[] leaveDays) retu
 }
 
 # Retrieves the private email recipients for a given user.
-# Private comments are visible only to the applicant and their lead.
 #
 # + email - The email of the user for whom private recipients are to be determined
-# + userAddedRecipients - Unused for private comments
+# + userAddedRecipients - A list of additional recipients added by the user
 # + token - The authorization token to retrieve user details
 # + return - A readonly array of private email recipients or an error if the operation fails
 public isolated function getPrivateRecipientsForUser(string email, string[] userAddedRecipients, string token)
     returns readonly & string[]|error {
+    map<true> recipientMap = {
+        [email]: true
+    };
     readonly & Employee employee = check employee:getEmployee(email);
-    return [email, <string>employee.leadEmail].cloneReadOnly();
+    recipientMap[<string>employee.leadEmail] = true;
+    foreach string recipient in userAddedRecipients {
+        recipientMap[recipient] = true;
+    }
+    foreach string defaultRecipient in defaultRecipients {
+        if recipientMap.hasKey(defaultRecipient) {
+            _ = recipientMap.remove(defaultRecipient);
+        }
+    }
+
+    return recipientMap.keys().cloneReadOnly();
 }
 
 # Get UTC date from a string in ISO 8601 format. This date will be timezone independent.

--- a/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
+++ b/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
@@ -345,7 +345,7 @@ export default function GeneralLeave() {
         <Typography variant="caption" sx={{ color: theme.palette.customText.primary.p4.active }}>
           {isPublicComment
             ? "Your comment will be visible to all email recipients."
-            : "Your comment will be visible to all email recipients except vacation-group@wso2.com."}
+            : "Your comment will be visible to all email recipients except the WSO2 Vacation Group."}
         </Typography>
         <Button
           variant="contained"

--- a/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
+++ b/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
@@ -345,7 +345,7 @@ export default function GeneralLeave() {
         <Typography variant="caption" sx={{ color: theme.palette.customText.primary.p4.active }}>
           {isPublicComment
             ? "Your comment will be visible to all email recipients."
-            : "Your comment will be visible to all recipients except for the vacation-group@wso2.com."}
+            : "Your comment will be visible to all email recipients except vacation-group@wso2.com."}
         </Typography>
         <Button
           variant="contained"

--- a/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
+++ b/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
@@ -221,7 +221,7 @@ export default function GeneralLeave() {
 
     showConfirmation(
       "Do you want to submit this leave?",
-      `This will submit a ${leaveLabel} request for ${workingDays} working day${workingDays !== 1 ? "s" : ""} (${dateRange}, ${portionLabel}). This action cannot be undone.`,
+      `This will submit a ${leaveLabel} request for ${workingDays} working day${workingDays !== 1 ? "s" : ""} (${dateRange}, ${portionLabel}).`,
       ConfirmationType.send,
       () => executeSubmit(periodType, isMorningLeave),
       "Yes",

--- a/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
+++ b/apps/leave-app/webapp/src/view/GeneralLeave/GeneralLeave.tsx
@@ -345,7 +345,7 @@ export default function GeneralLeave() {
         <Typography variant="caption" sx={{ color: theme.palette.customText.primary.p4.active }}>
           {isPublicComment
             ? "Your comment will be visible to all email recipients."
-            : "Your comment will only be visible to your lead."}
+            : "Your comment will be visible to all recipients except for the vacation-group@wso2.com."}
         </Typography>
         <Button
           variant="contained"


### PR DESCRIPTION
This pull request updates the user guidance in the `GeneralLeave` component to clarify the visibility of comments when they are not marked as public.

- **UI Text Update:**
  * Updated the non-public comment caption in `GeneralLeave.tsx` to specify that comments will be visible to all recipients except for `vacation-group@wso2.com`, instead of only being visible to the user's lead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the helper text displayed for private comments in leave requests to accurately reflect which recipients can view the comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->