### PR TITLE
[People App] Improvements in No rows found scenario

### DIFF
--- a/apps/people-app/webapp/src/theme.ts
+++ b/apps/people-app/webapp/src/theme.ts
@@ -165,6 +165,9 @@ export const themeSettings = (mode: PaletteMode) => {
           columnHeaderTitle: {
             fontWeight: 1000,
           },
+          virtualScroller: {
+            minHeight: 120,
+          },
         },
       },
       MuiButton: {

--- a/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
@@ -348,6 +348,7 @@ export default function EmployeesTable() {
           columns={columns}
           rows={isLoading ? [] : rows}
           getRowId={(row: Employee) => row.employeeId}
+          localeText={{ noRowsLabel: "No employees" }}
           pagination
           paginationMode="server"
           rowCount={employeeState.filteredEmployeesResponse.totalCount ?? 0}

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
@@ -300,6 +300,7 @@ export default function MyTeamTable() {
           columns={columns}
           rows={isLoading ? [] : rows}
           getRowId={(row: Employee) => row.employeeId}
+          localeText={{ noRowsLabel: "No employees" }}
           pagination
           paginationMode="server"
           rowCount={employeeState.filteredEmployeesResponse.totalCount ?? 0}

--- a/apps/people-app/webapp/src/view/masterData/EntityTab.tsx
+++ b/apps/people-app/webapp/src/view/masterData/EntityTab.tsx
@@ -284,6 +284,7 @@ export default function EntityTab({
           rows={isLoading ? [] : filteredEntities}
           columns={columns}
           loading={isLoading}
+          localeText={{ noRowsLabel: `No ${entityLabel.toLowerCase()}s` }}
           initialState={{
             pagination: { paginationModel: { pageSize: DEFAULT_LIMIT_VALUE } },
           }}


### PR DESCRIPTION
This pull request makes several improvements to the user interface of data tables in the people app, focusing on better user feedback and visual consistency. The main changes include adding custom "no rows" messages to various tables and adjusting the minimum height of the virtual scroller for enhanced appearance.

User feedback improvements:

* Added custom `noRowsLabel` messages to the `EmployeesTable`, `MyTeamTable`, and `EntityTab` components to provide clearer feedback when no data is available. (`EmployeesTable.tsx` [[1]](diffhunk://#diff-7fe648dc523aa35ac79c493869860abdfe579a65dbaa3a68eef59737ed1d7291R351) `MyTeamTable.tsx` [[2]](diffhunk://#diff-626eea05d28647c62edad01f81b739ea294fdc75a41074a73bc5eb9663e5cbe3R303) `EntityTab.tsx` [[3]](diffhunk://#diff-88de8d784fbc4c8cd98213deae0589b85f112ef839f228666dc0848ca3b34631R287)

Visual consistency:

* Set a minimum height for the `virtualScroller` in the table theme settings to ensure consistent table appearance, even when no data is present. (`theme.ts` [apps/people-app/webapp/src/theme.tsR168-R170](diffhunk://#diff-a0f137584f7a252e13b68cea4711d4e587d35ed668b278d20512e366e1b29d00R168-R170))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added styling for DataGrid virtual scroller to improve layout appearance
  * Updated empty-state messages across employee and master data tables for consistency ("No employees", "No [entity]s")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->