### PR TITLE
[People App] Employee onboarding fixes

### DIFF
--- a/apps/people-app/backend/Dependencies.toml
+++ b/apps/people-app/backend/Dependencies.toml
@@ -61,9 +61,10 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"}
 ]
 modules = [
 	{org = "ballerina", packageName = "data.csv", moduleName = "data.csv"}
@@ -125,7 +126,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -256,7 +257,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -323,7 +324,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -498,10 +498,18 @@ isolated function generateBulkEmployeeId(CreateEmployeePayload payload,
 
     match context.employmentType {
         PERMANENT|INTERNSHIP => {
+            if context.companyPrefix.trim().length() == 0 {
+                return error(string `Company (ID: ${payload.companyId}) has no employee ID prefix configured`);
+            }
+            // PERMANENT and PROBATION share one number line; INTERNSHIP runs a separate one.
+            // Scope both the MAX query and the in-batch cache key to the matching group.
+            EmploymentTypeName[] sequenceTypes = context.employmentType == PERMANENT
+                ? [PERMANENT, PROBATION]
+                : [INTERNSHIP];
             string seqKey = context.companyPrefix + ":" + context.employmentType.toString();
             if !sequenceCache.hasKey(seqKey) {
                 EmployeeIdSequence seq = check getLastEmployeeNumericSuffix(
-                        context.companyPrefix, [context.employmentType]);
+                        context.companyPrefix, sequenceTypes);
                 sequenceCache[seqKey] = <int>seq.lastNumericId;
             }
             int next = (sequenceCache[seqKey] ?: 0) + 1;

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -498,23 +498,27 @@ isolated function generateBulkEmployeeId(CreateEmployeePayload payload,
 
     match context.employmentType {
         PERMANENT|INTERNSHIP => {
-            if context.companyPrefix.trim().length() == 0 {
+            // Normalize the prefix once so a value like " SG " can't pass the guard, leak spaces
+            // into the ID, or fork a separate sequence from "SG".
+            string companyPrefix = context.companyPrefix.trim();
+            if companyPrefix.length() == 0 {
                 return error(string `Company (ID: ${payload.companyId}) has no employee ID prefix configured`);
             }
             // PERMANENT and PROBATION share one number line; INTERNSHIP runs a separate one.
-            // Scope both the MAX query and the in-batch cache key to the matching group.
+            // Scope both the MAX query and the in-batch cache key to the matching group. PROBATION
+            // never reaches this path (inactive types are rejected during bulk validation).
             EmploymentTypeName[] sequenceTypes = context.employmentType == PERMANENT
                 ? [PERMANENT, PROBATION]
                 : [INTERNSHIP];
-            string seqKey = context.companyPrefix + ":" + context.employmentType.toString();
+            string seqKey = companyPrefix + ":" + context.employmentType.toString();
             if !sequenceCache.hasKey(seqKey) {
                 EmployeeIdSequence seq = check getLastEmployeeNumericSuffix(
-                        context.companyPrefix, sequenceTypes);
+                        companyPrefix, sequenceTypes);
                 sequenceCache[seqKey] = <int>seq.lastNumericId;
             }
             int next = (sequenceCache[seqKey] ?: 0) + 1;
             sequenceCache[seqKey] = next;
-            return string `${context.companyPrefix}${next}`;
+            return string `${companyPrefix}${next}`;
         }
         CONSULTANCY|ADVISORY_CONSULTANCY|PART_TIME_CONSULTANCY => {
             string seqKey = CONSULTANCY_ID_PREFIX;

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1316,12 +1316,13 @@ isolated function addEmployeePersonalInfoQuery(CreatePersonalInfoPayload payload
 #
 # + companyId - Company ID of the new employee
 # + employmentTypeId - Employment type ID of the new employee
-# + return - Query returning `companyPrefix` and `employmentType` columns
+# + return - Query returning `companyPrefix`, `employmentType` and `isActive` columns
 isolated function getEmployeeIdContextQuery(int companyId, int employmentTypeId)
     returns sql:ParameterizedQuery =>
     `SELECT
         c.prefix        AS companyPrefix,
-        UPPER(et.name)  AS employmentType
+        UPPER(et.name)  AS employmentType,
+        et.is_active    AS isActive
     FROM employment_type et
     JOIN company c ON c.id = ${companyId}
     WHERE et.id = ${employmentTypeId}`;

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1208,7 +1208,8 @@ isolated function getOfficesQuery(int? companyId = ()) returns sql:Parameterized
 isolated function getEmploymentTypesQuery() returns sql:ParameterizedQuery =>
     `SELECT
         id,
-        name
+        name,
+        is_active
     FROM employment_type;`;
 
 # Fetch IDP group names mapped to a given employment type.

--- a/apps/people-app/backend/modules/database/enums.bal
+++ b/apps/people-app/backend/modules/database/enums.bal
@@ -43,6 +43,7 @@ public enum EmployeeStatus {
 # [Database] Enum for employment types.
 public enum EmploymentTypeName {
     PERMANENT = "PERMANENT",
+    PROBATION = "PROBATION",
     INTERNSHIP = "INTERNSHIP",
     CONSULTANCY = "CONSULTANCY",
     ADVISORY_CONSULTANCY = "ADVISORY CONSULTANCY",

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -106,6 +106,8 @@ public type EmployeeIdContext record {|
     string companyPrefix;
     # Employment type
     EmploymentTypeName employmentType;
+    # Whether the employment type is active (inactive types cannot be onboarded)
+    boolean isActive;
 |};
 
 # Result record for the last numeric suffix query used in employee ID generation.

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -613,6 +613,9 @@ public type EmploymentType record {|
     int id;
     # Name of the employment type
     string name;
+    # Whether the employment type is active
+    @sql:Column {name: "is_active"}
+    boolean isActive;
 |};
 
 # House.

--- a/apps/people-app/backend/resources/people_app_table_update_v1.0.19.sql
+++ b/apps/people-app/backend/resources/people_app_table_update_v1.0.19.sql
@@ -1,0 +1,22 @@
+-- Backfill the company.prefix (country code) for all existing companies.
+-- Employee IDs are generated as `<company.prefix><number>`, so a blank prefix
+-- produces a malformed, code-less ID. Each code below is the leading alphabetic
+-- prefix already embedded in that company's existing PERMANENT/INTERNSHIP
+-- employee IDs (the types that carry the company prefix); the dominant code per
+-- company was used. Companies with no employees to derive from (Malaysia,
+-- South Africa) use their ISO codes. Canada keeps 'CD' to stay consistent with
+-- its existing employee IDs rather than the ISO 'CA'.
+UPDATE company SET prefix = 'US' WHERE id = 1;   -- WSO2 - US
+UPDATE company SET prefix = 'UK' WHERE id = 2;   -- WSO2 - UK
+UPDATE company SET prefix = 'BR' WHERE id = 3;   -- WSO2 - BRAZIL
+UPDATE company SET prefix = 'DE' WHERE id = 4;   -- WSO2 Germany GmbH
+UPDATE company SET prefix = 'AU' WHERE id = 5;   -- WSO2 - AUSTRALIA
+UPDATE company SET prefix = 'LK' WHERE id = 6;   -- WSO2 - SRI LANKA
+UPDATE company SET prefix = 'AE' WHERE id = 7;   -- WSO2 - UAE
+UPDATE company SET prefix = 'IN' WHERE id = 8;   -- WSO2 - INDIA
+UPDATE company SET prefix = 'SG' WHERE id = 9;   -- WSO2 - SG
+UPDATE company SET prefix = 'MY' WHERE id = 10;  -- WSO2 - MALAYSIA (no employees; ISO)
+UPDATE company SET prefix = 'ES' WHERE id = 13;  -- WSO2 - SPAIN
+UPDATE company SET prefix = 'ZA' WHERE id = 15;  -- WSO2 - SOUTH AFRICA (no employees; ISO)
+UPDATE company SET prefix = 'CD' WHERE id = 16;  -- WSO2 - CANADA (matches existing CD... IDs)
+UPDATE company SET prefix = 'NZ' WHERE id = 17;  -- WSO2 - NEW ZEALAND

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -16,9 +16,9 @@
 
 import people.authorization;
 import people.database;
-import people.email;
+// import people.email;
 import people.qr;
-import people.scim;
+// import people.scim;
 import people.wso2_coin;
 
 import ballerina/http;
@@ -1076,94 +1076,94 @@ service http:InterceptableService / on new http:Listener(9090) {
         foreach int i in 0 ..< bulkResults.length() {
             payloadResult.employees[i].employeeId = bulkResults[i][0];
         }
-        int created = 0;
+        int created = payloadResult.employees.length();
 
         database:BulkProvisioningError[] provisioningErrors = [];
         database:BulkGroupAssignmentWarning[] groupAssignmentWarnings = [];
         database:OrphanedScimUser[] orphanedScimUsers = [];
 
-        foreach ResolvedEmployee emp in payloadResult.employees {
-            error? scimResult = scim:createUser(
-                    emp.payload.workEmail,
-                    emp.payload.firstName,
-                    emp.payload.lastName
-            );
-
-            if scimResult is error {
-                log:printError("Failed to provision user in Asgardeo during bulk onboarding; rolling back employee record",
-                        scimResult, workEmail = emp.payload.workEmail, employeeId = emp.employeeId);
-                rollbackEmployeeCreation(emp.employeeId, emp.payload.workEmail);
-                provisioningErrors.push({
-                    employeeId: emp.employeeId,
-                    workEmail: emp.payload.workEmail,
-                    reason: scimResult.message()
-                });
-                continue;
-            }
-
-            string[]|error groupNames = database:getAsgardeoGroupsByEmploymentType(emp.payload.employmentTypeId);
-            if groupNames is error {
-                log:printError("Failed to fetch Asgardeo groups during bulk onboarding; rolling back employee record. " +
-                        "Asgardeo user was already created and requires manual cleanup",
-                        groupNames, workEmail = emp.payload.workEmail, employeeId = emp.employeeId,
-                        employmentTypeId = emp.payload.employmentTypeId);
-                rollbackEmployeeCreation(emp.employeeId, emp.payload.workEmail);
-                provisioningErrors.push({
-                    employeeId: emp.employeeId,
-                    workEmail: emp.payload.workEmail,
-                    reason: groupNames.message()
-                });
-                orphanedScimUsers.push({
-                    employeeId: emp.employeeId,
-                    workEmail: emp.payload.workEmail,
-                    reason: groupNames.message()
-                });
-                continue;
-            }
-
-            string[] allGroups = [...groupNames];
-            string[]|error teamGroupNames = database:getAsgardeoGroupsByTeam(emp.payload.teamId, emp.payload.employmentTypeId);
-            if teamGroupNames is string[] {
-                allGroups.push(...teamGroupNames);
-            } else {
-                log:printError("Failed to fetch Asgardeo groups for team during bulk onboarding; skipping team group assignment",
-                        teamGroupNames, workEmail = emp.payload.workEmail, employeeId = emp.employeeId, teamId = emp.payload.teamId);
-            }
-
-            string[] uniqueGroups = from var groupName in allGroups
-                group by groupName
-                select groupName;
-
-            string[] failedGroups = [];
-            foreach string groupName in uniqueGroups {
-                scim:AddUsersToGroupResponse|error addResult =
-                        scim:addUserToGroup(groupName, emp.payload.workEmail);
-                if addResult is error || addResult.failedUsers.length() > 0 {
-                    log:printError("Failed to add user to Asgardeo group during bulk onboarding. " +
-                            "Asgardeo user was already created and requires manual cleanup",
-                                addResult is error ? addResult : (),
-                            workEmail = emp.payload.workEmail, group = groupName, employeeId = emp.employeeId,
-                            failedUsers = addResult is scim:AddUsersToGroupResponse ? addResult.failedUsers : ());
-                    failedGroups.push(groupName);
-                }
-            }
-
-            if failedGroups.length() > 0 {
-                error? notificationResult = email:notifyGroupAssignmentFailure(emp.employeeId, emp.payload.firstName,
-                        emp.payload.lastName, emp.payload.workEmail, failedGroups);
-                if notificationResult is error {
-                    log:printError("Failed to send group assignment failure notification during bulk onboarding",
-                            notificationResult, employeeId = emp.employeeId, workEmail = emp.payload.workEmail);
-                }
-                groupAssignmentWarnings.push({
-                    employeeId: emp.employeeId,
-                    workEmail: emp.payload.workEmail,
-                    failedGroups
-                });
-            }
-
-            created += 1;
-        }
+        // foreach ResolvedEmployee emp in payloadResult.employees {
+        //     error? scimResult = scim:createUser(
+        //             emp.payload.workEmail,
+        //             emp.payload.firstName,
+        //             emp.payload.lastName
+        //     );
+        //
+        //     if scimResult is error {
+        //         log:printError("Failed to provision user in Asgardeo during bulk onboarding; rolling back employee record",
+        //                 scimResult, workEmail = emp.payload.workEmail, employeeId = emp.employeeId);
+        //         rollbackEmployeeCreation(emp.employeeId, emp.payload.workEmail);
+        //         provisioningErrors.push({
+        //             employeeId: emp.employeeId,
+        //             workEmail: emp.payload.workEmail,
+        //             reason: scimResult.message()
+        //         });
+        //         continue;
+        //     }
+        //
+        //     string[]|error groupNames = database:getAsgardeoGroupsByEmploymentType(emp.payload.employmentTypeId);
+        //     if groupNames is error {
+        //         log:printError("Failed to fetch Asgardeo groups during bulk onboarding; rolling back employee record. " +
+        //                 "Asgardeo user was already created and requires manual cleanup",
+        //                 groupNames, workEmail = emp.payload.workEmail, employeeId = emp.employeeId,
+        //                 employmentTypeId = emp.payload.employmentTypeId);
+        //         rollbackEmployeeCreation(emp.employeeId, emp.payload.workEmail);
+        //         provisioningErrors.push({
+        //             employeeId: emp.employeeId,
+        //             workEmail: emp.payload.workEmail,
+        //             reason: groupNames.message()
+        //         });
+        //         orphanedScimUsers.push({
+        //             employeeId: emp.employeeId,
+        //             workEmail: emp.payload.workEmail,
+        //             reason: groupNames.message()
+        //         });
+        //         continue;
+        //     }
+        //
+        //     string[] allGroups = [...groupNames];
+        //     string[]|error teamGroupNames = database:getAsgardeoGroupsByTeam(emp.payload.teamId, emp.payload.employmentTypeId);
+        //     if teamGroupNames is string[] {
+        //         allGroups.push(...teamGroupNames);
+        //     } else {
+        //         log:printError("Failed to fetch Asgardeo groups for team during bulk onboarding; skipping team group assignment",
+        //                 teamGroupNames, workEmail = emp.payload.workEmail, employeeId = emp.employeeId, teamId = emp.payload.teamId);
+        //     }
+        //
+        //     string[] uniqueGroups = from var groupName in allGroups
+        //         group by groupName
+        //         select groupName;
+        //
+        //     string[] failedGroups = [];
+        //     foreach string groupName in uniqueGroups {
+        //         scim:AddUsersToGroupResponse|error addResult =
+        //                 scim:addUserToGroup(groupName, emp.payload.workEmail);
+        //         if addResult is error || addResult.failedUsers.length() > 0 {
+        //             log:printError("Failed to add user to Asgardeo group during bulk onboarding. " +
+        //                     "Asgardeo user was already created and requires manual cleanup",
+        //                         addResult is error ? addResult : (),
+        //                     workEmail = emp.payload.workEmail, group = groupName, employeeId = emp.employeeId,
+        //                     failedUsers = addResult is scim:AddUsersToGroupResponse ? addResult.failedUsers : ());
+        //             failedGroups.push(groupName);
+        //         }
+        //     }
+        //
+        //     if failedGroups.length() > 0 {
+        //         error? notificationResult = email:notifyGroupAssignmentFailure(emp.employeeId, emp.payload.firstName,
+        //                 emp.payload.lastName, emp.payload.workEmail, failedGroups);
+        //         if notificationResult is error {
+        //             log:printError("Failed to send group assignment failure notification during bulk onboarding",
+        //                     notificationResult, employeeId = emp.employeeId, workEmail = emp.payload.workEmail);
+        //         }
+        //         groupAssignmentWarnings.push({
+        //             employeeId: emp.employeeId,
+        //             workEmail: emp.payload.workEmail,
+        //             failedGroups
+        //         });
+        //     }
+        //
+        //     created += 1;
+        // }
 
         return {
             created,
@@ -1261,84 +1261,84 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        error? scimUserResult = scim:createUser(
-                payload.workEmail,
-                payload.firstName,
-                payload.lastName
-        );
-        if scimUserResult is error {
-            log:printError("Failed to provision user in Asgardeo; rolling back employee record",
-                    scimUserResult, workEmail = payload.workEmail, employeeId = employeeId);
-            rollbackEmployeeCreation(employeeId, payload.workEmail);
-            return <http:InternalServerError>{
-                body: {
-                    message: ERROR_EMPLOYEE_CREATION_FAILED
-                }
-            };
-        }
+        // error? scimUserResult = scim:createUser(
+        //         payload.workEmail,
+        //         payload.firstName,
+        //         payload.lastName
+        // );
+        // if scimUserResult is error {
+        //     log:printError("Failed to provision user in Asgardeo; rolling back employee record",
+        //             scimUserResult, workEmail = payload.workEmail, employeeId = employeeId);
+        //     rollbackEmployeeCreation(employeeId, payload.workEmail);
+        //     return <http:InternalServerError>{
+        //         body: {
+        //             message: ERROR_EMPLOYEE_CREATION_FAILED
+        //         }
+        //     };
+        // }
 
-        string[]|error groupNames = database:getAsgardeoGroupsByEmploymentType(payload.employmentTypeId);
-        if groupNames is error {
-            log:printError("Failed to fetch Asgardeo groups for employment type; rolling back employee record. " +
-                    "Asgardeo user was already created and requires manual cleanup",
-                    groupNames, workEmail = payload.workEmail, employeeId = employeeId,
-                    employmentTypeId = payload.employmentTypeId);
-            rollbackEmployeeCreation(employeeId, payload.workEmail);
-            return <http:InternalServerError>{
-                body: {
-                    message: ERROR_EMPLOYEE_CREATION_FAILED,
-                    orphanedScimUsers: [
-                        {
-                            employeeId,
-                            workEmail: payload.workEmail,
-                            reason: groupNames.message()
-                        }
-                    ]
-                }
-            };
-        }
+        // string[]|error groupNames = database:getAsgardeoGroupsByEmploymentType(payload.employmentTypeId);
+        // if groupNames is error {
+        //     log:printError("Failed to fetch Asgardeo groups for employment type; rolling back employee record. " +
+        //             "Asgardeo user was already created and requires manual cleanup",
+        //             groupNames, workEmail = payload.workEmail, employeeId = employeeId,
+        //             employmentTypeId = payload.employmentTypeId);
+        //     rollbackEmployeeCreation(employeeId, payload.workEmail);
+        //     return <http:InternalServerError>{
+        //         body: {
+        //             message: ERROR_EMPLOYEE_CREATION_FAILED,
+        //             orphanedScimUsers: [
+        //                 {
+        //                     employeeId,
+        //                     workEmail: payload.workEmail,
+        //                     reason: groupNames.message()
+        //                 }
+        //             ]
+        //         }
+        //     };
+        // }
 
-        string[] allGroups = [...groupNames];
-        string[]|error teamGroupNames = database:getAsgardeoGroupsByTeam(payload.teamId, payload.employmentTypeId);
-        if teamGroupNames is string[] {
-            allGroups.push(...teamGroupNames);
-        } else {
-            log:printError("Failed to fetch Asgardeo groups for team; skipping team group assignment",
-                    teamGroupNames, workEmail = payload.workEmail, employeeId = employeeId, teamId = payload.teamId);
-        }
+        // string[] allGroups = [...groupNames];
+        // string[]|error teamGroupNames = database:getAsgardeoGroupsByTeam(payload.teamId, payload.employmentTypeId);
+        // if teamGroupNames is string[] {
+        //     allGroups.push(...teamGroupNames);
+        // } else {
+        //     log:printError("Failed to fetch Asgardeo groups for team; skipping team group assignment",
+        //             teamGroupNames, workEmail = payload.workEmail, employeeId = employeeId, teamId = payload.teamId);
+        // }
 
-        string[] uniqueGroups = from var groupName in allGroups
-            group by groupName
-            select groupName;
+        // string[] uniqueGroups = from var groupName in allGroups
+        //     group by groupName
+        //     select groupName;
 
-        string[] failedGroups = [];
-        foreach string groupName in uniqueGroups {
-            scim:AddUsersToGroupResponse|error addResult =
-                    scim:addUserToGroup(groupName, payload.workEmail);
-            if addResult is error || addResult.failedUsers.length() > 0 {
-                log:printError("Failed to add user to Asgardeo group. " +
-                        "Asgardeo user was already created and requires manual cleanup",
-                            addResult is error ? addResult : (),
-                        workEmail = payload.workEmail, group = groupName, employeeId = employeeId,
-                        failedUsers = addResult is scim:AddUsersToGroupResponse ? addResult.failedUsers : ());
-                failedGroups.push(groupName);
-            }
-        }
+        // string[] failedGroups = [];
+        // foreach string groupName in uniqueGroups {
+        //     scim:AddUsersToGroupResponse|error addResult =
+        //             scim:addUserToGroup(groupName, payload.workEmail);
+        //     if addResult is error || addResult.failedUsers.length() > 0 {
+        //         log:printError("Failed to add user to Asgardeo group. " +
+        //                 "Asgardeo user was already created and requires manual cleanup",
+        //                     addResult is error ? addResult : (),
+        //                 workEmail = payload.workEmail, group = groupName, employeeId = employeeId,
+        //                 failedUsers = addResult is scim:AddUsersToGroupResponse ? addResult.failedUsers : ());
+        //         failedGroups.push(groupName);
+        //     }
+        // }
 
-        if failedGroups.length() > 0 {
-            error? notificationResult = email:notifyGroupAssignmentFailure(employeeId, payload.firstName,
-                    payload.lastName, payload.workEmail, failedGroups);
-            if notificationResult is error {
-                log:printError("Failed to send group assignment failure notification",
-                        notificationResult, employeeId = employeeId, workEmail = payload.workEmail);
-            }
+        // if failedGroups.length() > 0 {
+        //     error? notificationResult = email:notifyGroupAssignmentFailure(employeeId, payload.firstName,
+        //             payload.lastName, payload.workEmail, failedGroups);
+        //     if notificationResult is error {
+        //         log:printError("Failed to send group assignment failure notification",
+        //                 notificationResult, employeeId = employeeId, workEmail = payload.workEmail);
+        //     }
 
-            return {
-                employeeId: newEmployeeId,
-                message: WARNING_GROUP_ASSIGNMENT_FAILED,
-                hasGroupAssignmentWarning: true
-            };
-        }
+        //     return {
+        //         employeeId: newEmployeeId,
+        //         message: WARNING_GROUP_ASSIGNMENT_FAILED,
+        //         hasGroupAssignmentWarning: true
+        //     };
+        // }
         return {
             employeeId: newEmployeeId,
             message: "Employee created successfully!",

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -16,10 +16,12 @@
 
 import people.authorization;
 import people.database;
-// import people.email;
 import people.qr;
-// import people.scim;
 import people.wso2_coin;
+// Temporarily disabled together with the Asgardeo/SCIM provisioning blocks in the onboarding
+// handlers below (see the NOTE there). Re-enable these imports when provisioning is restored.
+// import people.email;
+// import people.scim;
 
 import ballerina/http;
 import ballerina/log;
@@ -1082,6 +1084,11 @@ service http:InterceptableService / on new http:Listener(9090) {
         database:BulkGroupAssignmentWarning[] groupAssignmentWarnings = [];
         database:OrphanedScimUser[] orphanedScimUsers = [];
 
+        // NOTE: Asgardeo/SCIM provisioning is intentionally disabled for now and will be re-enabled
+        // shortly (tracked in PR #294). The block below is kept rather than deleted so re-enabling is
+        // a straightforward uncomment. While disabled, employees are created in the DB only; the
+        // provisioning arrays above stay empty, so the response reflects DB creation without
+        // provisioning (no SCIM user/group assignment is attempted).
         // foreach ResolvedEmployee emp in payloadResult.employees {
         //     error? scimResult = scim:createUser(
         //             emp.payload.workEmail,
@@ -1261,6 +1268,10 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        // NOTE: Asgardeo/SCIM provisioning is intentionally disabled for now and will be re-enabled
+        // shortly (tracked in PR #294). The block below is kept rather than deleted so re-enabling is
+        // a straightforward uncomment. While disabled, the employee is created in the DB only and the
+        // response returns hasGroupAssignmentWarning: false (no SCIM user/group assignment attempted).
         // error? scimUserResult = scim:createUser(
         //         payload.workEmail,
         //         payload.firstName,

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -43,8 +43,24 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
 
     match ctx.employmentType {
         database:PERMANENT|database:INTERNSHIP => {
+            if ctx.companyPrefix.trim().length() == 0 {
+                string customErr = string `The selected company (ID: ${payload.companyId}) has no employee ` +
+                    "ID prefix configured. Set the company prefix before onboarding.";
+                log:printWarn(customErr, companyId = payload.companyId, employmentType = ctx.employmentType);
+                return <http:BadRequest>{
+                    body: {
+                        message: customErr
+                    }
+                };
+            }
+            // PERMANENT and PROBATION share one number line (an employee keeps the same ID
+            // across probation -> permanent); INTERNSHIP runs a separate line. Scope the
+            // sequence to the matching group so the two never collide.
+            database:EmploymentTypeName[] sequenceTypes = ctx.employmentType == database:PERMANENT
+                ? [database:PERMANENT, database:PROBATION]
+                : [database:INTERNSHIP];
             database:EmployeeIdSequence|error row = database:getLastEmployeeNumericSuffix(
-                    ctx.companyPrefix, [ctx.employmentType]
+                    ctx.companyPrefix, sequenceTypes
             );
             if row is error {
                 string customErr = "Error occurred while fetching last employee numeric suffix";

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -41,9 +41,27 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
         };
     }
 
+    // Reject inactive employment types (e.g. PROBATION). The frontend already hides them, but a
+    // direct API call could still send one; without this it would fall through to the unsupported
+    // 500 path. PROBATION stays non-onboardable here yet is still counted in the PERMANENT line below.
+    if !ctx.isActive {
+        string customErr = string `Employment type (ID: ${payload.employmentTypeId}) is inactive ` +
+            "and cannot be used for onboarding.";
+        log:printWarn(customErr, employmentTypeId = payload.employmentTypeId, employmentType = ctx.employmentType);
+        return <http:BadRequest>{
+            body: {
+                message: customErr
+            }
+        };
+    }
+
+    // Normalize the prefix once so a value like " SG " can't pass the empty-prefix guard, leak
+    // spaces into the ID, or fork a separate numeric sequence from "SG".
+    string companyPrefix = ctx.companyPrefix.trim();
+
     match ctx.employmentType {
         database:PERMANENT|database:INTERNSHIP => {
-            if ctx.companyPrefix.trim().length() == 0 {
+            if companyPrefix.length() == 0 {
                 string customErr = string `The selected company (ID: ${payload.companyId}) has no employee ` +
                     "ID prefix configured. Set the company prefix before onboarding.";
                 log:printWarn(customErr, companyId = payload.companyId, employmentType = ctx.employmentType);
@@ -53,25 +71,26 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
                     }
                 };
             }
-            // PERMANENT and PROBATION share one number line (an employee keeps the same ID
-            // across probation -> permanent); INTERNSHIP runs a separate line. Scope the
-            // sequence to the matching group so the two never collide.
+            // PERMANENT and PROBATION share one number line (an employee keeps the same ID across
+            // probation -> permanent); INTERNSHIP runs a separate line. PROBATION is intentionally
+            // counted here but not onboardable (rejected by the is_active check above) -- do not add
+            // a PROBATION match arm or re-key this ternary off it.
             database:EmploymentTypeName[] sequenceTypes = ctx.employmentType == database:PERMANENT
                 ? [database:PERMANENT, database:PROBATION]
                 : [database:INTERNSHIP];
             database:EmployeeIdSequence|error row = database:getLastEmployeeNumericSuffix(
-                    ctx.companyPrefix, sequenceTypes
+                    companyPrefix, sequenceTypes
             );
             if row is error {
                 string customErr = "Error occurred while fetching last employee numeric suffix";
-                log:printError(customErr, row, employmentType = ctx.employmentType, companyPrefix = ctx.companyPrefix);
+                log:printError(customErr, row, employmentType = ctx.employmentType, companyPrefix = companyPrefix);
                 return <http:InternalServerError>{
                     body: {
                         message: customErr
                     }
                 };
             }
-            return string `${ctx.companyPrefix}${<int>row.lastNumericId + 1}`;
+            return string `${companyPrefix}${<int>row.lastNumericId + 1}`;
         }
         database:CONSULTANCY|database:ADVISORY_CONSULTANCY|database:PART_TIME_CONSULTANCY => {
             database:EmployeeIdSequence|error row = database:getLastEmployeeNumericSuffix(
@@ -104,7 +123,7 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
                 };
             }
 
-            if manualId.startsWith(ctx.companyPrefix) && re `[0-9]+`.isFullMatch(manualId.substring(ctx.companyPrefix.length()))
+            if manualId.startsWith(companyPrefix) && re `[0-9]+`.isFullMatch(manualId.substring(companyPrefix.length()))
                 || manualId.startsWith(database:CONSULTANCY_ID_PREFIX) && re `[0-9]+`.
                     isFullMatch(manualId.substring(database:CONSULTANCY_ID_PREFIX.length())) {
                 string customErr = string `Employee ID '${manualId}' is reserved for auto-generation and cannot be assigned manually`;
@@ -218,7 +237,10 @@ isolated function loadBulkReferenceData() returns BulkRefData|error {
             select [normalizeKey(u_row.name), u_row.id],
         designationIds: map from database:Designation d_row in designations
             select [normalizeKey(d_row.designation), d_row.id],
+        // Only active types are valid for onboarding; mirrors the frontend filter so a CSV row
+        // naming an inactive type (e.g. PROBATION) is rejected during validation.
         employmentTypeIds: map from database:EmploymentType et_row in employmentTypes
+            where et_row.isActive
             select [normalizeKey(et_row.name), et_row.id],
         companyIds: map from database:CompanyResponse c_row in companies
             select [normalizeKey(c_row.name), c_row.id],

--- a/apps/people-app/webapp/src/route.ts
+++ b/apps/people-app/webapp/src/route.ts
@@ -31,6 +31,8 @@ import GroupsIcon from "@mui/icons-material/Groups";
 import PersonOffIcon from "@mui/icons-material/PersonOff";
 import QrCode2Icon from "@mui/icons-material/QrCode2";
 import GroupAddIcon from "@mui/icons-material/GroupAdd";
+import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
+import UploadFileIcon from "@mui/icons-material/UploadFile";
 import PeopleAltIcon from "@mui/icons-material/PeopleAlt";
 import { Role } from "@slices/authSlice/auth";
 import { isIncludedRole } from "@utils/utils";
@@ -83,6 +85,14 @@ const ReportsRoot = () => {
   return React.createElement(Outlet);
 };
 
+const OnboardingRoot = () => {
+  const { pathname } = useLocation();
+  if (pathname === "/onboarding") {
+    return React.createElement(Navigate, { to: "/onboarding/single", replace: true });
+  }
+  return React.createElement(Outlet);
+};
+
 
 export const routes: RouteObjectWithRole[] = [
   {
@@ -119,8 +129,24 @@ export const routes: RouteObjectWithRole[] = [
     path: "/onboarding",
     text: "Onboarding",
     icon: React.createElement(GroupAddIcon),
-    element: React.createElement(View.employeeOnboarding),
+    element: React.createElement(OnboardingRoot),
     allowRoles: [Role.ADMIN],
+    children: [
+      {
+        path: "/onboarding/single",
+        text: "Single",
+        icon: React.createElement(PersonAddAlt1Icon),
+        element: React.createElement(View.employeeOnboarding),
+        allowRoles: [Role.ADMIN],
+      },
+      {
+        path: "/onboarding/bulk",
+        text: "Bulk",
+        icon: React.createElement(UploadFileIcon),
+        element: React.createElement(View.bulkOnboarding),
+        allowRoles: [Role.ADMIN],
+      },
+    ],
   },
   // Top-level My Team entry shown only for lead-only users (hidden when the user also has admin
   // access, since admin+lead users see My Team nested under Employees instead).

--- a/apps/people-app/webapp/src/slices/organizationSlice/organization.ts
+++ b/apps/people-app/webapp/src/slices/organizationSlice/organization.ts
@@ -74,6 +74,7 @@ export interface Office {
 export interface EmploymentType {
   id: number;
   name: string;
+  isActive: boolean;
 }
 
 export interface House {

--- a/apps/people-app/webapp/src/view/employees/onboarding/bulkOnboarding/BulkOnboardingView.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/bulkOnboarding/BulkOnboardingView.tsx
@@ -15,14 +15,14 @@
 // under the License.
 
 import CommonPage from "@layout/pages/CommonPage";
-import EmployeeForm from "@view/employees/onboarding/EmployeeForm";
+import BulkOnboarding from "@view/employees/onboarding/bulkOnboarding/BulkOnboarding";
 
-export default function EmployeeOnboarding() {
+export default function BulkOnboardingView() {
   return (
     <CommonPage
-      title="Single Onboarding"
+      title="Bulk Onboarding"
       commonPageTabs={[]}
-      page={<EmployeeForm mode="create" />}
+      page={<BulkOnboarding />}
     />
   );
 }

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -549,6 +549,16 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
     return t?.id ?? null;
   }, [employmentTypes]);
 
+  // Only active types are selectable for onboarding, but keep the currently
+  // selected type (edit mode may load an employee on a now-inactive type).
+  const selectableEmploymentTypes = useMemo(
+    () =>
+      employmentTypes.filter(
+        (t) => t.isActive || t.id === values.employmentTypeId,
+      ),
+    [employmentTypes, values.employmentTypeId],
+  );
+
   const [internshipDurationMonths, setInternshipDurationMonths] =
     useState<number>(0);
 
@@ -1387,7 +1397,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               sx={textFieldSx}
             >
               {employmentTypes.length > 0 ? (
-                employmentTypes.map((type) => (
+                selectableEmploymentTypes.map((type) => (
                   <MenuItem key={type.id} value={type.id}>
                     {type.name}
                   </MenuItem>

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -1396,7 +1396,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               disabled={organizationState === "loading"}
               sx={textFieldSx}
             >
-              {employmentTypes.length > 0 ? (
+              {selectableEmploymentTypes.length > 0 ? (
                 selectableEmploymentTypes.map((type) => (
                   <MenuItem key={type.id} value={type.id}>
                     {type.name}
@@ -1406,7 +1406,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                 <MenuItem disabled>
                   {organizationState === "loading"
                     ? "Loading employment types..."
-                    : "No employment types available"}
+                    : "No active employment types available"}
                 </MenuItem>
               )}
             </TextField>

--- a/apps/people-app/webapp/src/view/index.tsx
+++ b/apps/people-app/webapp/src/view/index.tsx
@@ -18,7 +18,7 @@ import { lazy } from "react";
 
 const me = lazy(() => import("@view/me"));
 const employeeOnboarding = lazy(() => import("@view/employees/onboarding/singleOnboarding/employeeOnboarding"));
-const bulkOnboarding = lazy(() => import("@view/employees/onboarding/bulkOnboarding/BulkOnboarding"));
+const bulkOnboarding = lazy(() => import("@view/employees/onboarding/bulkOnboarding/BulkOnboardingView"));
 const employeesList = lazy(() => import("@view/employees/employeesView/EmployeesView"));
 const help = lazy(() => import("@view/help/help"));
 const employeeDetails = lazy(() => import("@view/employees/employeeDetail/employeeDetail"));


### PR DESCRIPTION
## Summary
Fixed employee-ID generation for country-coded company prefixes, restructured the onboarding navigation, filtered inactive employment types, and disabled Asgardeo provisioning in bulk onboarding (to be re-enabled later).

## What changed

1. Employee-ID generation (backend)
2. Company prefix backfill (DB migration)
3. Filter inactive employment types (full stack)
4. Bulk onboarding → nested sidenav (frontend)
5. Disable Asgardeo provisioning in bulk onboarding (backend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk onboarding added as a dedicated view and route; onboarding now has separate single and bulk pages
  * "Probation" added as an employment type; employment-type data now includes active/inactive status

* **Bug Fixes**
  * Employee ID generation trims/validates company prefixes and rejects inactive employment types
  * Employment type selector shows only active options (but preserves current selection)

* **Chores**
  * Backend dependency patch updates
  * Database backfill script to populate company prefixes
* **Behavior Change**
  * External provisioning/group-assignment flows disabled; responses include empty provisioning arrays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->