### PR TITLE
[People App] Employees view improvements

### DIFF
--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -117,6 +117,7 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
                 THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END
         ) AS designation,
         e.designation_id AS designationId,
+        d.job_band AS jobBand,
         e.secondary_job_title AS secondaryJobTitle,
         e.job_role AS jobRole,
         o.name AS office,
@@ -310,8 +311,14 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
     appendStringFilter(filters, payload.filters.residentNumber, `pi.resident_number = ${payload.filters.residentNumber}`);
     appendStringFilter(filters, payload.filters.city, `LOWER(pi.city) = LOWER(${payload.filters.city})`);
     appendStringFilter(filters, payload.filters.country, `LOWER(pi.country) = LOWER(${payload.filters.country})`);
+    string[]? statusList = payload.filters.employeeStatuses;
     string? statusFilter = payload.filters.employeeStatus;
-    if statusFilter is string {
+    if statusList is string[] && statusList.length() > 0 {
+        // Multi-select status takes precedence over the single status + includeMarkedLeavers flag.
+        string[] loweredStatuses = from string status in statusList
+            select status.toLowerAscii();
+        filters.push(sql:queryConcat(`LOWER(e.employee_status) IN (`, buildInClause(loweredStatuses), `)`));
+    } else if statusFilter is string {
         if payload.filters.includeMarkedLeavers == true {
             filters.push(`(LOWER(e.employee_status) = LOWER(${statusFilter}) OR e.employee_status = 'Marked leaver')`);
         } else {
@@ -335,7 +342,13 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
     appendIntFilter(filters, payload.filters.teamId, `e.team_id = ${payload.filters.teamId}`);
     appendIntFilter(filters, payload.filters.subTeamId, `e.sub_team_id = ${payload.filters.subTeamId}`);
     appendIntFilter(filters, payload.filters.unitId, `e.unit_id = ${payload.filters.unitId}`);
-    appendIntFilter(filters, payload.filters.employmentTypeId, `e.employment_type_id = ${payload.filters.employmentTypeId}`);
+    int[]? employmentTypeList = payload.filters.employmentTypeIds;
+    if employmentTypeList is int[] && employmentTypeList.length() > 0 {
+        // Multi-select employment type takes precedence over the single employmentTypeId.
+        filters.push(sql:queryConcat(`e.employment_type_id IN (`, buildIntInClause(employmentTypeList), `)`));
+    } else {
+        appendIntFilter(filters, payload.filters.employmentTypeId, `e.employment_type_id = ${payload.filters.employmentTypeId}`);
+    }
 
     if payload.filters.excludeFutureStartDate == true {
         filters.push(`e.start_date <= CURDATE()`);
@@ -660,6 +673,20 @@ isolated function getExistingEpfsQuery(string[] epfs) returns sql:ParameterizedQ
 # + values - List of string values to include in the IN clause
 # + return - Parameterized query representing the IN clause
 isolated function buildInClause(string[] values) returns sql:ParameterizedQuery {
+    sql:ParameterizedQuery clause = ``;
+    foreach int i in 0 ..< values.length() {
+        clause = i == 0
+            ? sql:queryConcat(clause, `${values[i]}`)
+            : sql:queryConcat(clause, `, `, `${values[i]}`);
+    }
+    return clause;
+}
+
+# Build an SQL IN clause for a list of integer values.
+#
+# + values - List of integer values to include in the IN clause
+# + return - Parameterized query representing the IN clause
+isolated function buildIntInClause(int[] values) returns sql:ParameterizedQuery {
     sql:ParameterizedQuery clause = ``;
     foreach int i in 0 ..< values.length() {
         clause = i == 0

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -252,8 +252,12 @@ public type EmployeeFilters record {|
     int? designationId = ();
     # Employment type ID
     int? employmentTypeId = ();
+    # Employment type IDs (multi-select). When non-empty, takes precedence over employmentTypeId.
+    int[]? employmentTypeIds = ();
     # Employee Status
     string? employeeStatus = ();
+    # Employee Statuses (multi-select). When non-empty, takes precedence over employeeStatus/includeMarkedLeavers.
+    string[]? employeeStatuses = ();
     # Direct reports only (true = direct only, false = all subordinates recursively)
     boolean? directReports = ();
     # When true, excludes employees whose start date is in the future

--- a/apps/people-app/webapp/src/layout/header/index.tsx
+++ b/apps/people-app/webapp/src/layout/header/index.tsx
@@ -132,6 +132,7 @@ const Header = () => {
                     }}
                     src={user.userInfo?.employeeThumbnail || ""}
                     alt={user.userInfo?.firstName || "Avatar"}
+                    imgProps={{ referrerPolicy: "no-referrer" }}
                   >
                     {user.userInfo?.firstName?.charAt(0)}
                   </Avatar>

--- a/apps/people-app/webapp/src/slices/employeeSlice/employee.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employee.ts
@@ -742,6 +742,7 @@ const EmployeeSlice = createSlice({
         const statuses = filters.employeeStatuses ?? [];
         const isBaselineQuery =
           !searchString &&
+          filters.excludeFutureStartDate === true &&
           statuses.length === 2 &&
           statuses.includes(EmployeeStatus.Active) &&
           statuses.includes(EmployeeStatus.MarkedLeaver) &&

--- a/apps/people-app/webapp/src/slices/employeeSlice/employee.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employee.ts
@@ -148,9 +148,11 @@ export type Filters = {
   companyId?: number;
   officeId?: number;
   employmentTypeId?: number;
+  employmentTypeIds?: number[];
   managerEmail?: string;
   gender?: string;
   employeeStatus?: EmployeeStatus;
+  employeeStatuses?: EmployeeStatus[];
   directReports?: boolean;
   excludeFutureStartDate?: boolean;
   includeMarkedLeavers?: boolean;
@@ -283,7 +285,7 @@ const initialState: EmployeesState = {
   managersState: State.idle,
   employeeFilter: {
     filters: {
-      employeeStatus: EmployeeStatus.Active,
+      employeeStatuses: [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver],
       excludeFutureStartDate: true,
     },
     pagination: {
@@ -736,13 +738,17 @@ const EmployeeSlice = createSlice({
         state.stateMessage = "Filtered employees fetched successfully";
         state.errorMessage = null;
         const { searchString, filters } = action.meta.arg;
-        const isTotalActiveQuery =
+        // Capture the baseline count on the default query (Active + Marked leaver, no other filters).
+        const statuses = filters.employeeStatuses ?? [];
+        const isBaselineQuery =
           !searchString &&
-          filters.employeeStatus === EmployeeStatus.Active &&
+          statuses.length === 2 &&
+          statuses.includes(EmployeeStatus.Active) &&
+          statuses.includes(EmployeeStatus.MarkedLeaver) &&
           Object.entries(filters).every(([key, value]) => {
-            return key === "employeeStatus" || key === "excludeFutureStartDate" || value === undefined;
+            return key === "employeeStatuses" || key === "excludeFutureStartDate" || value === undefined;
           });
-        if (isTotalActiveQuery) {
+        if (isBaselineQuery) {
           state.totalActiveEmployeeCount = action.payload.totalCount;
         }
       })

--- a/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
@@ -29,7 +29,7 @@ import { State } from "@src/types/types";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { SearchForm } from "../searchForm/SearchForm";
-import { getEmployeeStatusColor } from "@utils/utils";
+import { formatDate, getEmployeeStatusColor } from "@utils/utils";
 
 export default function EmployeesTable() {
   const theme = useTheme();
@@ -106,23 +106,18 @@ export default function EmployeesTable() {
             width: "100%",
           }}
         >
-          {params.row.employeeThumbnail ? (
-            <Avatar
-              src={params.row.employeeThumbnail}
-              alt={getFullName(params.row.firstName, params.row.lastName)}
-              sx={{ width: 32, height: 32 }}
-            />
-          ) : (
-            <Avatar
-              sx={{
-                width: 32,
-                height: 32,
-                bgcolor: theme.palette.primary.main,
-              }}
-            >
-              {params.row.firstName?.[0]?.toUpperCase() || "E"}
-            </Avatar>
-          )}
+          <Avatar
+            src={params.row.employeeThumbnail ?? undefined}
+            alt={getFullName(params.row.firstName, params.row.lastName)}
+            imgProps={{ referrerPolicy: "no-referrer" }}
+            sx={{
+              width: 32,
+              height: 32,
+              bgcolor: theme.palette.primary.main,
+            }}
+          >
+            {params.row.firstName?.[0]?.toUpperCase() || "E"}
+          </Avatar>
           <Box
             sx={{
               fontWeight: 600,
@@ -168,36 +163,6 @@ export default function EmployeesTable() {
       ),
     },
     {
-      field: "businessUnit",
-      headerName: "Business Unit",
-      flex: 0.8,
-      minWidth: 140,
-      resizable: false,
-      renderCell: (params: GridRenderCellParams<Employee>) => (
-        <Tooltip title={params.value || "N/A"} arrow>
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 0.5,
-              overflow: "hidden",
-            }}
-          >
-            <Box
-              sx={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                color: theme.palette.text.primary,
-              }}
-            >
-              {params.value || "N/A"}
-            </Box>
-          </Box>
-        </Tooltip>
-      ),
-    },
-    {
       field: "team",
       headerName: "Team",
       flex: 0.8,
@@ -219,11 +184,56 @@ export default function EmployeesTable() {
       ),
     },
     {
+      field: "designation",
+      headerName: "Designation",
+      flex: 0.9,
+      minWidth: 150,
+      resizable: false,
+      renderCell: (params: GridRenderCellParams<Employee>) => (
+        <Tooltip title={params.value || "N/A"} arrow>
+          <Box
+            sx={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: theme.palette.text.primary,
+            }}
+          >
+            {params.value || "N/A"}
+          </Box>
+        </Tooltip>
+      ),
+    },
+    {
+      field: "startDate",
+      headerName: "Start Date",
+      width: 120,
+      resizable: false,
+      valueGetter: (_value, row) => formatDate(row.startDate, "-"),
+      renderCell: (params: GridRenderCellParams<Employee>) => (
+        <Box sx={{ color: theme.palette.text.primary }}>{params.value}</Box>
+      ),
+    },
+    {
       field: "employmentType",
       headerName: "Employment Type",
       flex: 0.7,
       minWidth: 130,
       resizable: false,
+      renderCell: (params: GridRenderCellParams<Employee>) => (
+        <Tooltip title={params.value || "N/A"} arrow>
+          <Box
+            sx={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: theme.palette.text.primary,
+            }}
+          >
+            {params.value || "N/A"}
+          </Box>
+        </Tooltip>
+      ),
     },
     {
       field: "employeeStatus",
@@ -293,8 +303,8 @@ export default function EmployeesTable() {
                   );
                 }
                 
-                // Email and Business Unit columns
-                if (col.field === "workEmail" || col.field === "businessUnit") {
+                // Email and other text columns
+                if (col.field === "workEmail" || col.field === "designation") {
                   return (
                     <Box key={colIndex} sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
                       <Skeleton variant="rectangular" width="70%" height={24} sx={{ borderRadius: 3 }} />

--- a/apps/people-app/webapp/src/view/employees/employeesView/searchForm/FilterDrawer.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/searchForm/FilterDrawer.tsx
@@ -89,6 +89,10 @@ type FilterDrawerProps = {
   showExcludeFutureFilter?: boolean;
   /** When true, renders an "Include marked leavers" toggle (Active Employees report). Default false. */
   showIncludeMarkedLeaversFilter?: boolean;
+  /** When true, the Employment Type filter is a multi-select bound to `employmentTypeIds`. Default false. */
+  multiSelectEmploymentType?: boolean;
+  /** When true, the Employee Status filter is a multi-select bound to `employeeStatuses`. Default false. */
+  multiSelectStatus?: boolean;
 };
 
 export function FilterDrawer({
@@ -112,6 +116,8 @@ export function FilterDrawer({
   showEmployeeStatusFilter = true,
   showExcludeFutureFilter = true,
   showIncludeMarkedLeaversFilter = false,
+  multiSelectEmploymentType = false,
+  multiSelectStatus = false,
 }: FilterDrawerProps) {
   const theme = useTheme();
   const [draft, setDraft] = useState<EmployeeSearchPayload>(appliedFilter);
@@ -234,24 +240,48 @@ export function FilterDrawer({
               Other
             </Typography>
             <Stack spacing={2}>
-              <Autocomplete<EmploymentType, false, false, false>
-                options={sortAndFormatOptions(employmentTypes, (et) => et.name)}
-                getOptionLabel={(o) => toSentenceCase(o.name)}
-                value={
-                  employmentTypes.find(
-                    (et) => et.id === draft.filters.employmentTypeId,
-                  ) ?? null
-                }
-                autoHighlight
-                autoSelect
-                onChange={(_, selected) =>
-                  set({ employmentTypeId: selected?.id || undefined })
-                }
-                ListboxProps={{ style: { maxHeight: 240, overflow: "auto" } }}
-                renderInput={(params) => (
-                  <BaseTextField {...params} size="small" label="Employment Type" />
-                )}
-              />
+              {multiSelectEmploymentType ? (
+                <Autocomplete<EmploymentType, true, false, false>
+                  multiple
+                  options={sortAndFormatOptions(employmentTypes, (et) => et.name)}
+                  getOptionLabel={(o) => toSentenceCase(o.name)}
+                  value={employmentTypes.filter((et) =>
+                    (draft.filters.employmentTypeIds ?? []).includes(et.id),
+                  )}
+                  isOptionEqualToValue={(opt, val) => opt.id === val.id}
+                  autoHighlight
+                  onChange={(_, selected) =>
+                    set({
+                      employmentTypeIds: selected.length
+                        ? selected.map((s) => s.id)
+                        : undefined,
+                    })
+                  }
+                  ListboxProps={{ style: { maxHeight: 240, overflow: "auto" } }}
+                  renderInput={(params) => (
+                    <BaseTextField {...params} size="small" label="Employment Type" />
+                  )}
+                />
+              ) : (
+                <Autocomplete<EmploymentType, false, false, false>
+                  options={sortAndFormatOptions(employmentTypes, (et) => et.name)}
+                  getOptionLabel={(o) => toSentenceCase(o.name)}
+                  value={
+                    employmentTypes.find(
+                      (et) => et.id === draft.filters.employmentTypeId,
+                    ) ?? null
+                  }
+                  autoHighlight
+                  autoSelect
+                  onChange={(_, selected) =>
+                    set({ employmentTypeId: selected?.id || undefined })
+                  }
+                  ListboxProps={{ style: { maxHeight: 240, overflow: "auto" } }}
+                  renderInput={(params) => (
+                    <BaseTextField {...params} size="small" label="Employment Type" />
+                  )}
+                />
+              )}
               <Autocomplete<string, false, false, false>
                 options={managerEmails}
                 getOptionLabel={(email) => email}
@@ -281,21 +311,37 @@ export function FilterDrawer({
                   <BaseTextField {...params} size="small" label="Gender" />
                 )}
               />
-              {showEmployeeStatusFilter && (
-                <Autocomplete<EmployeeStatus, false, false, false>
-                  options={sortAndFormatOptions(Object.values(EmployeeStatus), (s) => s)}
-                  getOptionLabel={(o) => toSentenceCase(o)}
-                  value={Object.values(EmployeeStatus).find((es) => es === draft.filters.employeeStatus) ?? null}
-                  autoHighlight
-                  autoSelect
-                  onChange={(_, selected) =>
-                    set({ employeeStatus: selected || undefined })
-                  }
-                  renderInput={(params) => (
-                    <BaseTextField {...params} size="small" label="Employee Status" />
-                  )}
-                />
-              )}
+              {showEmployeeStatusFilter &&
+                (multiSelectStatus ? (
+                  <Autocomplete<EmployeeStatus, true, false, false>
+                    multiple
+                    options={sortAndFormatOptions(Object.values(EmployeeStatus), (s) => s)}
+                    getOptionLabel={(o) => toSentenceCase(o)}
+                    value={draft.filters.employeeStatuses ?? []}
+                    isOptionEqualToValue={(opt, val) => opt === val}
+                    autoHighlight
+                    onChange={(_, selected) =>
+                      set({ employeeStatuses: selected.length ? selected : undefined })
+                    }
+                    renderInput={(params) => (
+                      <BaseTextField {...params} size="small" label="Employee Status" />
+                    )}
+                  />
+                ) : (
+                  <Autocomplete<EmployeeStatus, false, false, false>
+                    options={sortAndFormatOptions(Object.values(EmployeeStatus), (s) => s)}
+                    getOptionLabel={(o) => toSentenceCase(o)}
+                    value={Object.values(EmployeeStatus).find((es) => es === draft.filters.employeeStatus) ?? null}
+                    autoHighlight
+                    autoSelect
+                    onChange={(_, selected) =>
+                      set({ employeeStatus: selected || undefined })
+                    }
+                    renderInput={(params) => (
+                      <BaseTextField {...params} size="small" label="Employee Status" />
+                    )}
+                  />
+                ))}
               {showDirectReportsFilter && (
                 <FormControlLabel
                   control={

--- a/apps/people-app/webapp/src/view/employees/employeesView/searchForm/FilterDrawer.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/searchForm/FilterDrawer.tsx
@@ -255,6 +255,7 @@ export function FilterDrawer({
                       employmentTypeIds: selected.length
                         ? selected.map((s) => s.id)
                         : undefined,
+                      employmentTypeId: undefined,
                     })
                   }
                   ListboxProps={{ style: { maxHeight: 240, overflow: "auto" } }}
@@ -274,7 +275,10 @@ export function FilterDrawer({
                   autoHighlight
                   autoSelect
                   onChange={(_, selected) =>
-                    set({ employmentTypeId: selected?.id || undefined })
+                    set({
+                      employmentTypeId: selected?.id || undefined,
+                      employmentTypeIds: undefined,
+                    })
                   }
                   ListboxProps={{ style: { maxHeight: 240, overflow: "auto" } }}
                   renderInput={(params) => (
@@ -321,7 +325,11 @@ export function FilterDrawer({
                     isOptionEqualToValue={(opt, val) => opt === val}
                     autoHighlight
                     onChange={(_, selected) =>
-                      set({ employeeStatuses: selected.length ? selected : undefined })
+                      set({
+                        employeeStatuses: selected.length ? selected : undefined,
+                        employeeStatus: undefined,
+                        includeMarkedLeavers: undefined,
+                      })
                     }
                     renderInput={(params) => (
                       <BaseTextField {...params} size="small" label="Employee Status" />
@@ -335,7 +343,10 @@ export function FilterDrawer({
                     autoHighlight
                     autoSelect
                     onChange={(_, selected) =>
-                      set({ employeeStatus: selected || undefined })
+                      set({
+                        employeeStatus: selected || undefined,
+                        employeeStatuses: undefined,
+                      })
                     }
                     renderInput={(params) => (
                       <BaseTextField {...params} size="small" label="Employee Status" />

--- a/apps/people-app/webapp/src/view/employees/employeesView/searchForm/SearchForm.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/searchForm/SearchForm.tsx
@@ -33,6 +33,7 @@ import {
   Grid,
   IconButton,
   InputAdornment,
+  Skeleton,
   Stack,
   Tooltip,
   Typography,
@@ -52,7 +53,6 @@ import {
   CareerFunction,
   Company,
   Designation,
-  EmploymentType,
   fetchBusinessUnits,
   fetchCareerFunctions,
   fetchCompanies,
@@ -87,8 +87,6 @@ type ChipConfig =
   | ChipMeta<"manager", string>
   | ChipMeta<"company", Company>
   | ChipMeta<"office", Office>
-  | ChipMeta<"employmentType", EmploymentType>
-  | ChipMeta<"employeeStatus", EmployeeStatus>
   | ChipMeta<"gender", string>;
 
 export function SearchForm() {
@@ -174,7 +172,10 @@ export function SearchForm() {
     dispatch(
       setEmployeeFilter({
         searchString: normalizedSearchString,
-        filters: {},
+        filters: {
+          employeeStatuses: [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver],
+          excludeFutureStartDate: true,
+        },
         pagination: {
           limit: DEFAULT_LIMIT_VALUE,
           offset: DEFAULT_OFFSET_VALUE,
@@ -195,11 +196,11 @@ export function SearchForm() {
       careerFunctionId,
       designationId,
       gender,
-      employmentTypeId,
+      employmentTypeIds,
       managerEmail,
       companyId,
       officeId,
-      employeeStatus,
+      employeeStatuses,
       excludeFutureStartDate,
     } = filters;
 
@@ -211,11 +212,11 @@ export function SearchForm() {
       careerFunctionId ||
       gender ||
       designationId ||
-      employmentTypeId ||
+      employmentTypeIds?.length ||
       managerEmail ||
       companyId ||
       officeId ||
-      employeeStatus ||
+      employeeStatuses?.length ||
       excludeFutureStartDate,
     );
   }
@@ -230,11 +231,11 @@ export function SearchForm() {
       careerFunctionId,
       designationId,
       gender,
-      employmentTypeId,
+      employmentTypeIds,
       managerEmail,
       companyId,
       officeId,
-      employeeStatus,
+      employeeStatuses,
       excludeFutureStartDate,
     } = filterPayload.filters;
     return [
@@ -245,17 +246,33 @@ export function SearchForm() {
       careerFunctionId,
       designationId,
       gender,
-      employmentTypeId,
+      employmentTypeIds?.length,
       managerEmail,
       companyId,
       officeId,
-      employeeStatus,
+      employeeStatuses?.length,
       excludeFutureStartDate,
     ].filter(Boolean).length;
   }, [filterPayload.filters]);
 
   // Check if any of the filters are active
   const active = activeFilterCount > 0;
+
+  // Shared style for the multi-select filter chips (Employment Type, Status).
+  const accentColor = theme.palette.secondary.contrastText;
+  const multiFilterChipSx = {
+    height: "32px",
+    borderRadius: "50px",
+    fontSize: "12px",
+    fontWeight: 600,
+    color: theme.palette.mode === "dark" ? theme.palette.grey[100] : theme.palette.grey[800],
+    backgroundColor: alpha(accentColor, theme.palette.mode === "dark" ? 0.12 : 0.06),
+    border: `1.5px solid ${accentColor}`,
+    "& .MuiChip-deleteIcon": {
+      color: theme.palette.text.disabled,
+      "&:hover": { color: theme.palette.error.main },
+    },
+  };
 
   // Derive manager emails
   const managerEmails = useMemo(() => {
@@ -375,23 +392,6 @@ export function SearchForm() {
           updateSearchPayload({ filters: { officeId: undefined } }),
       },
       {
-        kind: "employmentType",
-        label: "Employment Type",
-        value: toSentenceCase(employmentTypes.find(
-          (et) => et.id === filterPayload.filters.employmentTypeId,
-        )?.name ?? ""),
-        options: sortAndFormatOptions(employmentTypes, (et) => et.name),
-        getLabel: (employeeType: EmploymentType) => toSentenceCase(employeeType.name),
-        onChange: (employeeType: EmploymentType) =>
-          updateSearchPayload({
-            filters: { employmentTypeId: employeeType.id },
-          }),
-        onClear: () =>
-          updateSearchPayload({
-            filters: { employmentTypeId: undefined },
-          }),
-      },
-      {
         kind: "manager",
         label: "Manager",
         value: managerEmails.find(
@@ -403,17 +403,6 @@ export function SearchForm() {
           updateSearchPayload({ filters: { managerEmail } }),
         onClear: () =>
           updateSearchPayload({ filters: { managerEmail: undefined } }),
-      },
-      {
-        kind: "employeeStatus",
-        label: "Employee Status",
-        value: toSentenceCase(filterPayload.filters.employeeStatus ?? ""),
-        options: sortAndFormatOptions(Object.values(EmployeeStatus), (s) => s),
-        getLabel: (status: EmployeeStatus) => toSentenceCase(status),
-        onChange: (status: EmployeeStatus) =>
-          updateSearchPayload({ filters: { employeeStatus: status } }),
-        onClear: () =>
-          updateSearchPayload({ filters: { employeeStatus: undefined } }),
       },
       {
         kind: "gender",
@@ -431,13 +420,10 @@ export function SearchForm() {
       careerFunctions,
       companies,
       designations,
-      employmentTypes,
       filterPayload.filters.businessUnitId,
       filterPayload.filters.careerFunctionId,
       filterPayload.filters.companyId,
       filterPayload.filters.designationId,
-      filterPayload.filters.employeeStatus,
-      filterPayload.filters.employmentTypeId,
       filterPayload.filters.gender,
       filterPayload.filters.managerEmail,
       filterPayload.filters.officeId,
@@ -515,7 +501,7 @@ export function SearchForm() {
                           textTransform: "capitalize",
                         }}
                       >
-                        Total Active
+                        Total
                       </Box>
                       <Box
                         component="span"
@@ -529,10 +515,11 @@ export function SearchForm() {
                               : theme.palette.grey[800],
                         }}
                       >
-                        {isLoading &&
-                        employeeState.totalActiveEmployeeCount === null
-                          ? "—"
-                          : (employeeState.totalActiveEmployeeCount ?? "—")}
+                        {isLoading ? (
+                          <Skeleton variant="rounded" width={24} height={14} />
+                        ) : (
+                          (employeeState.totalActiveEmployeeCount ?? "—")
+                        )}
                       </Box>
                     </>
                   }
@@ -588,10 +575,11 @@ export function SearchForm() {
                                 : theme.palette.grey[800],
                           }}
                         >
-                          {isLoading
-                            ? "—"
-                            : employeeState.filteredEmployeesResponse
-                                .totalCount}
+                          {isLoading ? (
+                            <Skeleton variant="rounded" width={24} height={14} />
+                          ) : (
+                            employeeState.filteredEmployeesResponse.totalCount
+                          )}
                         </Box>
                       </>
                     }
@@ -821,18 +809,6 @@ export function SearchForm() {
                     const { kind, ...props } = config;
                     return <FilterChipSelect<Office> key={kind} {...props} />;
                   }
-                  case "employmentType": {
-                    const { kind, ...props } = config;
-                    return (
-                      <FilterChipSelect<EmploymentType> key={kind} {...props} />
-                    );
-                  }
-                  case "employeeStatus": {
-                    const { kind, ...props } = config;
-                    return (
-                      <FilterChipSelect<EmployeeStatus> key={kind} {...props} />
-                    );
-                  }
                   case "manager":
                   case "gender": {
                     const { kind, ...props } = config;
@@ -842,6 +818,42 @@ export function SearchForm() {
                     return assertNever(config);
                 }
               })}
+              {(filterPayload.filters.employmentTypeIds ?? []).map((id) => {
+                const employmentType = employmentTypes.find((et) => et.id === id);
+                if (!employmentType) return null;
+                return (
+                  <Chip
+                    key={`employmentType-${id}`}
+                    label={`Employment Type: ${toSentenceCase(employmentType.name)}`}
+                    variant="outlined"
+                    onDelete={() => {
+                      const next = (filterPayload.filters.employmentTypeIds ?? []).filter(
+                        (x) => x !== id,
+                      );
+                      updateSearchPayload({
+                        filters: { employmentTypeIds: next.length ? next : undefined },
+                      });
+                    }}
+                    sx={multiFilterChipSx}
+                  />
+                );
+              })}
+              {(filterPayload.filters.employeeStatuses ?? []).map((status) => (
+                <Chip
+                  key={`employeeStatus-${status}`}
+                  label={`Status: ${toSentenceCase(status)}`}
+                  variant="outlined"
+                  onDelete={() => {
+                    const next = (filterPayload.filters.employeeStatuses ?? []).filter(
+                      (s) => s !== status,
+                    );
+                    updateSearchPayload({
+                      filters: { employeeStatuses: next.length ? next : undefined },
+                    });
+                  }}
+                  sx={multiFilterChipSx}
+                />
+              ))}
               {hasActiveFilters && (
                 <Button
                   variant="text"
@@ -888,6 +900,8 @@ export function SearchForm() {
         managerEmails={managerEmails}
         companies={companies}
         offices={offices}
+        multiSelectEmploymentType
+        multiSelectStatus
       />
     </Box>
   );

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamSearchForm.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamSearchForm.tsx
@@ -183,10 +183,17 @@ export function MyTeamSearchForm({
 
   const activeFilterCount = useMemo(() => {
     const { businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, employeeStatuses, directReports, excludeFutureStartDate } = filterPayload.filters;
-    // employeeStatuses is always applied (Active + Marked leaver by default) — count it so the badge reflects it.
+    // Baseline (Active + Marked leaver, exclude future joiners) is the default — don't count it as an active filter.
+    const baselineStatuses = [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver];
+    const isBaselineStatuses =
+      (employeeStatuses?.length ?? 0) === baselineStatuses.length &&
+      baselineStatuses.every((status) => employeeStatuses?.includes(status));
+    const statusCount = isBaselineStatuses ? 0 : (employeeStatuses?.length ?? 0);
     // directReports defaults to false (show all); turning it on (Direct Reports Only) is an active filter.
     const directReportsOn = directReports === true;
-    return [businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, employeeStatuses?.length, directReportsOn || undefined, excludeFutureStartDate].filter(Boolean).length;
+    // excludeFutureStartDate defaults to true; only count it when the user opts to include future joiners.
+    const includeFutureStartDateFilter = excludeFutureStartDate === false;
+    return [businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, statusCount || undefined, directReportsOn || undefined, includeFutureStartDateFilter || undefined].filter(Boolean).length;
   }, [filterPayload.filters]);
 
   const active = activeFilterCount > 0;

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamSearchForm.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamSearchForm.tsx
@@ -34,6 +34,7 @@ import {
   Grid,
   IconButton,
   InputAdornment,
+  Skeleton,
   Stack,
   Switch,
   Tooltip,
@@ -85,7 +86,6 @@ type ChipConfig =
   | ChipMeta<"company", Company>
   | ChipMeta<"office", Office>
   | ChipMeta<"employmentType", EmploymentType>
-  | ChipMeta<"employeeStatus", EmployeeStatus>
   | ChipMeta<"gender", string>;
 
 interface MyTeamSearchFormProps {
@@ -165,7 +165,11 @@ export function MyTeamSearchForm({
     if (debounceRef.current) window.clearTimeout(debounceRef.current);
     onFilterChange({
       searchString: normalizeSearchString(searchText),
-      filters: { directReports: false },
+      filters: {
+        employeeStatuses: [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver],
+        directReports: false,
+        excludeFutureStartDate: true,
+      },
       pagination: { limit: DEFAULT_LIMIT_VALUE, offset: DEFAULT_OFFSET_VALUE },
       sort: filterRef.current.sort,
     });
@@ -178,15 +182,31 @@ export function MyTeamSearchForm({
   }
 
   const activeFilterCount = useMemo(() => {
-    const { businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, employeeStatus, directReports, excludeFutureStartDate } = filterPayload.filters;
-    // employeeStatus is always applied (Active by default) — count it so the badge reflects it.
+    const { businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, employeeStatuses, directReports, excludeFutureStartDate } = filterPayload.filters;
+    // employeeStatuses is always applied (Active + Marked leaver by default) — count it so the badge reflects it.
     // directReports defaults to false (show all); turning it on (Direct Reports Only) is an active filter.
     const directReportsOn = directReports === true;
-    return [businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, employeeStatus, directReportsOn || undefined, excludeFutureStartDate].filter(Boolean).length;
+    return [businessUnitId, teamId, subTeamId, unitId, careerFunctionId, designationId, gender, employmentTypeId, managerEmail, companyId, officeId, employeeStatuses?.length, directReportsOn || undefined, excludeFutureStartDate].filter(Boolean).length;
   }, [filterPayload.filters]);
 
   const active = activeFilterCount > 0;
   const managerEmails = useMemo(() => employeeState.managers.map((m) => m.workEmail), [employeeState.managers]);
+
+  // Shared style for the multi-select Status filter chips.
+  const accentColor = theme.palette.secondary.contrastText;
+  const multiFilterChipSx = {
+    height: "32px",
+    borderRadius: "50px",
+    fontSize: "12px",
+    fontWeight: 600,
+    color: theme.palette.mode === "dark" ? theme.palette.grey[100] : theme.palette.grey[800],
+    backgroundColor: alpha(accentColor, theme.palette.mode === "dark" ? 0.12 : 0.06),
+    border: `1.5px solid ${accentColor}`,
+    "& .MuiChip-deleteIcon": {
+      color: theme.palette.text.disabled,
+      "&:hover": { color: theme.palette.error.main },
+    },
+  };
 
   const filterChipConfigs = useMemo<ChipConfig[]>(
     () => [
@@ -281,15 +301,6 @@ export function MyTeamSearchForm({
         onClear: () => updateSearchPayload({ filters: { managerEmail: undefined } }),
       },
       {
-        kind: "employeeStatus",
-        label: "Employee Status",
-        value: toSentenceCase(filterPayload.filters.employeeStatus ?? ""),
-        options: sortAndFormatOptions(Object.values(EmployeeStatus), (s) => s),
-        getLabel: (s: EmployeeStatus) => toSentenceCase(s),
-        onChange: (s: EmployeeStatus) => updateSearchPayload({ filters: { employeeStatus: s } }),
-        onClear: () => updateSearchPayload({ filters: { employeeStatus: undefined } }),
-      },
-      {
         kind: "gender",
         label: "Gender",
         value: toSentenceCase(filterPayload.filters.gender ?? ""),
@@ -303,7 +314,7 @@ export function MyTeamSearchForm({
       businessUnits, careerFunctions, companies, designations, employmentTypes,
       filterPayload.filters.businessUnitId, filterPayload.filters.careerFunctionId,
       filterPayload.filters.companyId, filterPayload.filters.designationId,
-      filterPayload.filters.employeeStatus, filterPayload.filters.employmentTypeId,
+      filterPayload.filters.employmentTypeId,
       filterPayload.filters.gender, filterPayload.filters.managerEmail,
       filterPayload.filters.officeId, filterPayload.filters.subTeamId,
       filterPayload.filters.teamId, filterPayload.filters.unitId,
@@ -347,7 +358,7 @@ export function MyTeamSearchForm({
                           textTransform: "capitalize",
                         }}
                       >
-                        Total Active
+                        Total
                       </Box>
                       <Box
                         component="span"
@@ -358,7 +369,11 @@ export function MyTeamSearchForm({
                           color: theme.palette.mode === "dark" ? theme.palette.grey[100] : theme.palette.grey[800],
                         }}
                       >
-                        {isLoading && teamActiveCount === null ? "—" : (teamActiveCount ?? "—")}
+                        {isLoading ? (
+                          <Skeleton variant="rounded" width={24} height={14} />
+                        ) : (
+                          (teamActiveCount ?? "—")
+                        )}
                       </Box>
                     </>
                   }
@@ -400,7 +415,11 @@ export function MyTeamSearchForm({
                             color: theme.palette.mode === "dark" ? theme.palette.grey[100] : theme.palette.grey[800],
                           }}
                         >
-                          {isLoading ? "—" : employeeState.filteredEmployeesResponse.totalCount}
+                          {isLoading ? (
+                            <Skeleton variant="rounded" width={24} height={14} />
+                          ) : (
+                            employeeState.filteredEmployeesResponse.totalCount
+                          )}
                         </Box>
                       </>
                     }
@@ -593,12 +612,27 @@ export function MyTeamSearchForm({
                   case "company": { const { kind, ...props } = config; return <FilterChipSelect<Company> key={kind} {...props} />; }
                   case "office": { const { kind, ...props } = config; return <FilterChipSelect<Office> key={kind} {...props} />; }
                   case "employmentType": { const { kind, ...props } = config; return <FilterChipSelect<EmploymentType> key={kind} {...props} />; }
-                  case "employeeStatus": { const { kind, ...props } = config; return <FilterChipSelect<EmployeeStatus> key={kind} {...props} />; }
                   case "manager":
                   case "gender": { const { kind, ...props } = config; return <FilterChipSelect<string> key={kind} {...props} />; }
                   default: return assertNever(config);
                 }
               })}
+              {(filterPayload.filters.employeeStatuses ?? []).map((status) => (
+                <Chip
+                  key={`employeeStatus-${status}`}
+                  label={`Status: ${toSentenceCase(status)}`}
+                  variant="outlined"
+                  onDelete={() => {
+                    const next = (filterPayload.filters.employeeStatuses ?? []).filter(
+                      (s) => s !== status,
+                    );
+                    updateSearchPayload({
+                      filters: { employeeStatuses: next.length ? next : undefined },
+                    });
+                  }}
+                  sx={multiFilterChipSx}
+                />
+              ))}
               {hasActiveFilters && (
                 <Button
                   variant="text"
@@ -646,6 +680,7 @@ export function MyTeamSearchForm({
         companies={companies}
         offices={offices}
         showDirectReportsFilter
+        multiSelectStatus
       />
     </Box>
   );

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
@@ -51,7 +51,11 @@ export default function MyTeamTable() {
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
 
   const [filterState, setFilterState] = useState<Pick<EmployeeSearchPayload, "filters" | "searchString">>({
-    filters: { employeeStatus: EmployeeStatus.Active, directReports: false, excludeFutureStartDate: true },
+    filters: {
+      employeeStatuses: [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver],
+      directReports: false,
+      excludeFutureStartDate: true,
+    },
     searchString: undefined,
   });
 
@@ -97,12 +101,15 @@ export default function MyTeamTable() {
     dispatch(fetchFilteredEmployees(appliedFilter));
   }, [dispatch, appliedFilter]);
 
-  // Capture team active count when only the baseline Active filter is applied.
+  // Capture team count when only the baseline (Active + Marked leaver) filter is applied.
   // directReports is intentionally excluded: toggling it should still refresh the count.
   const isBaselineFilter = useMemo(() => {
-    const { employeeStatus, directReports: _dr, excludeFutureStartDate: _efd, ...rest } = filterState.filters;
+    const { employeeStatuses, directReports: _dr, excludeFutureStartDate: _efd, ...rest } = filterState.filters;
+    const statuses = employeeStatuses ?? [];
     return (
-      employeeStatus === EmployeeStatus.Active &&
+      statuses.length === 2 &&
+      statuses.includes(EmployeeStatus.Active) &&
+      statuses.includes(EmployeeStatus.MarkedLeaver) &&
       !Object.values(rest).some(Boolean) &&
       !filterState.searchString?.trim()
     );
@@ -141,17 +148,14 @@ export default function MyTeamTable() {
         resizable: false,
         renderCell: (params: GridRenderCellParams<Employee>) => (
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, width: "100%" }}>
-            {params.row.employeeThumbnail ? (
-              <Avatar
-                src={params.row.employeeThumbnail}
-                alt={getFullName(params.row.firstName, params.row.lastName)}
-                sx={{ width: 32, height: 32 }}
-              />
-            ) : (
-              <Avatar sx={{ width: 32, height: 32, bgcolor: theme.palette.primary.main }}>
-                {params.row.firstName?.[0]?.toUpperCase() || "E"}
-              </Avatar>
-            )}
+            <Avatar
+              src={params.row.employeeThumbnail ?? undefined}
+              alt={getFullName(params.row.firstName, params.row.lastName)}
+              imgProps={{ referrerPolicy: "no-referrer" }}
+              sx={{ width: 32, height: 32, bgcolor: theme.palette.primary.main }}
+            >
+              {params.row.firstName?.[0]?.toUpperCase() || "E"}
+            </Avatar>
             <Box
               sx={{
                 fontWeight: 600,

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
@@ -104,9 +104,10 @@ export default function MyTeamTable() {
   // Capture team count when only the baseline (Active + Marked leaver) filter is applied.
   // directReports is intentionally excluded: toggling it should still refresh the count.
   const isBaselineFilter = useMemo(() => {
-    const { employeeStatuses, directReports: _dr, excludeFutureStartDate: _efd, ...rest } = filterState.filters;
+    const { employeeStatuses, directReports: _dr, excludeFutureStartDate, ...rest } = filterState.filters;
     const statuses = employeeStatuses ?? [];
     return (
+      excludeFutureStartDate === true &&
       statuses.length === 2 &&
       statuses.includes(EmployeeStatus.Active) &&
       statuses.includes(EmployeeStatus.MarkedLeaver) &&

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -48,6 +48,7 @@ import {
   type ContinuousServiceRecordInfo,
 } from "@slices/employeeSlice/employee";
 import { EmployeeStatus } from "@/types/types";
+import { sortAndFormatOptions } from "@utils/utils";
 import {
   fetchBusinessUnits,
   fetchTeams,
@@ -459,7 +460,10 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
   );
 
   const managerEmailOptions = useMemo(() => {
-    const list = employeesBasicInfo.map((e) => e.workEmail).filter(Boolean);
+    const list = sortAndFormatOptions(
+      employeesBasicInfo.map((e) => e.workEmail).filter(Boolean),
+      (email) => email,
+    );
     if (values.managerEmail && !list.includes(values.managerEmail)) {
       return [values.managerEmail, ...list];
     }
@@ -467,7 +471,10 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
   }, [employeesBasicInfo, values.managerEmail]);
 
   const additionalManagerOptions = useMemo(() => {
-    const list = employeesBasicInfo.map((e) => e.workEmail).filter(Boolean);
+    const list = sortAndFormatOptions(
+      employeesBasicInfo.map((e) => e.workEmail).filter(Boolean),
+      (email) => email,
+    );
     const selected = values.additionalManagerEmail ?? [];
     const missing = selected.filter((email) => email && !list.includes(email));
     return [...missing, ...list];
@@ -1034,7 +1041,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               sx={textFieldSx}
             >
               {businessUnits.length ? (
-                businessUnits.map((b) => (
+                sortAndFormatOptions(businessUnits, (b) => b.name).map((b) => (
                   <MenuItem key={b.id} value={b.id}>
                     {b.name}
                   </MenuItem>
@@ -1067,7 +1074,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               }}
             >
               {teams.length ? (
-                teams.map((t) => (
+                sortAndFormatOptions(teams, (t) => t.name).map((t) => (
                   <MenuItem key={t.id} value={t.id}>
                     {t.name}
                   </MenuItem>
@@ -1102,7 +1109,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                 <em>None</em>
               </MenuItem>
               {subTeams.length ? (
-                subTeams.map((st) => (
+                sortAndFormatOptions(subTeams, (st) => st.name).map((st) => (
                   <MenuItem key={st.id} value={st.id}>
                     {st.name}
                   </MenuItem>
@@ -1137,7 +1144,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                 <em>None</em>
               </MenuItem>
               {units.length ? (
-                units.map((u) => (
+                sortAndFormatOptions(units, (u) => u.name).map((u) => (
                   <MenuItem key={u.id} value={u.id}>
                     {u.name}
                   </MenuItem>
@@ -1170,7 +1177,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               sx={textFieldSx}
             >
               {careerFunctions.length ? (
-                careerFunctions.map((cf) => (
+                sortAndFormatOptions(careerFunctions, (cf) => cf.careerFunction).map((cf) => (
                   <MenuItem key={cf.id} value={cf.id}>
                     {cf.careerFunction}
                   </MenuItem>
@@ -1207,7 +1214,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               }}
             >
               {designations.length ? (
-                designations.map((d) => (
+                sortAndFormatOptions(designations, (d) => d.designation).map((d) => (
                   <MenuItem key={d.id} value={d.id}>
                     {d.designation}
                   </MenuItem>
@@ -1277,7 +1284,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               sx={textFieldSx}
             >
               {companies.length ? (
-                companies.map((company) => (
+                sortAndFormatOptions(companies, (company) => company.name).map((company) => (
                   <MenuItem key={company.id} value={company.id}>
                     {company.name}
                   </MenuItem>
@@ -1308,7 +1315,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                 <em>None</em>
               </MenuItem>
               {offices.length ? (
-                offices.map((office) => (
+                sortAndFormatOptions(offices, (office) => office.name).map((office) => (
                   <MenuItem key={office.id} value={office.id}>
                     {office.name}
                   </MenuItem>
@@ -1343,7 +1350,10 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                       ?.allowedLocations ?? [];
 
                   return allowedLocations.length ? (
-                    allowedLocations.map((locationItem) => (
+                    sortAndFormatOptions(
+                      allowedLocations,
+                      (locationItem) => locationItem.location,
+                    ).map((locationItem) => (
                       <MenuItem
                         key={locationItem.location}
                         value={locationItem.location}
@@ -1397,7 +1407,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               sx={textFieldSx}
             >
               {selectableEmploymentTypes.length > 0 ? (
-                selectableEmploymentTypes.map((type) => (
+                sortAndFormatOptions(selectableEmploymentTypes, (type) => type.name).map((type) => (
                   <MenuItem key={type.id} value={type.id}>
                     {type.name}
                   </MenuItem>
@@ -1727,7 +1737,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               sx={textFieldSx}
             >
               {houses.length ? (
-                houses.map((h) => (
+                sortAndFormatOptions(houses, (h) => h.name).map((h) => (
                   <MenuItem key={h.id} value={h.id}>
                     {h.name}
                   </MenuItem>

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/PersonalInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/PersonalInfo.tsx
@@ -49,6 +49,7 @@ import {
   EmployeeGenders,
 } from "@root/src/config/constant";
 import { CreateEmployeeFormValues } from "@root/src/types/types";
+import { sortAndFormatOptions } from "@utils/utils";
 import dayjs from "dayjs";
 
 const PERSONAL_INFO_ICONS = {
@@ -555,7 +556,7 @@ export default function PersonalInfoStep() {
               }
               sx={textFieldSx}
             >
-              {Countries.map((c) => (
+              {sortAndFormatOptions(Countries, (c) => c).map((c) => (
                 <MenuItem key={c} value={c}>
                   {c}
                 </MenuItem>

--- a/apps/people-app/webapp/src/view/me/index.tsx
+++ b/apps/people-app/webapp/src/view/me/index.tsx
@@ -614,6 +614,7 @@ export default function Me({
               <>
                 <Avatar
                   src={employee?.employeeThumbnail ?? undefined}
+                  imgProps={{ referrerPolicy: "no-referrer" }}
                   sx={(theme) => avatarSx(theme)}
                 >
                   {employee?.firstName?.[0]?.toUpperCase() ?? ""}
@@ -787,6 +788,14 @@ export default function Me({
                   </Typography>
                   <Typography variant="h6" sx={{ fontWeight: 600 }}>
                     {designationText}
+                  </Typography>
+                </Grid>
+                <Grid item xs={12} sm={6} md={3}>
+                  <Typography color="text.secondary" sx={{ fontWeight: 500 }}>
+                    Job Band
+                  </Typography>
+                  <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                    {employee.jobBand ?? "-"}
                   </Typography>
                 </Grid>
               </Grid>

--- a/apps/people-app/webapp/src/view/reports/EmployeeReportTable.tsx
+++ b/apps/people-app/webapp/src/view/reports/EmployeeReportTable.tsx
@@ -689,9 +689,11 @@ export default function EmployeeReportTable({
                       : theme.palette.grey[800],
                 }}
               >
-                {isLoading
-                  ? "—"
-                  : (totalCount ?? "—")}
+                {isLoading ? (
+                  <Skeleton variant="rounded" width={24} height={14} />
+                ) : (
+                  (totalCount ?? "—")
+                )}
               </Box>
             </>
           }

--- a/apps/people-app/webapp/src/view/reports/QrCodesReport.tsx
+++ b/apps/people-app/webapp/src/view/reports/QrCodesReport.tsx
@@ -215,6 +215,7 @@ function QrCodesReportContent() {
             >
               <Avatar
                 src={option.employeeThumbnail ?? undefined}
+                imgProps={{ referrerPolicy: "no-referrer" }}
                 sx={{
                   width: 32,
                   height: 32,
@@ -300,6 +301,7 @@ function QrCodesReportContent() {
                   >
                     <Avatar
                       src={emp.employeeThumbnail ?? undefined}
+                      imgProps={{ referrerPolicy: "no-referrer" }}
                       sx={{
                         width: 36,
                         height: 36,


### PR DESCRIPTION
Employees view improvements:
- Profile picture loading fallback (initials on failure) + referrer policy
- Sorted onboarding dropdowns
- Employees/All columns: add Designation, Start Date; drop Business Unit
- Multi-select Employment Type + Status filters (default: Active + Marked leaver)
- Loading skeletons on count chips
- Show Job Band on Me / Employee Details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-select filtering for employment types and employee statuses
  * Job Band field added to employee details display
  * Start Date column now visible in employees table
  * Improved loading indicators with skeleton placeholders

* **Improvements**
  * Enhanced avatar image handling for better security
  * Optimized dropdown option sorting across onboarding forms
  * Simplified avatar rendering with automatic letter fallbacks
  * Removed Business Unit column from table view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->