### PR TITLE
[People App Microapp] Bugfix: Fix parking payment failure modal persisting across app relaunches

### DIFF
--- a/apps/people-app/microapp/src/components/ParkingWalletReturnResume.tsx
+++ b/apps/people-app/microapp/src/components/ParkingWalletReturnResume.tsx
@@ -25,6 +25,7 @@ import {
   PARKING_WALLET_PAYMENT_STATUS_KEY,
   PARKING_WALLET_PAYMENT_TX_HASH_KEY,
   PARKING_WALLET_PAYMENT_ERROR_KEY,
+  clearWalletParkingPaymentBridgeKeys,
   confirmParkingReservation,
   fetchParkingReservationById,
   finalizeParkingConfirmationAfterSuccess,
@@ -88,6 +89,8 @@ export function ParkingWalletReturnResume({
 
           if (status === "FAILED") {
             const error = await getLocalDataAsync(PARKING_WALLET_PAYMENT_ERROR_KEY);
+            await clearWalletParkingPaymentBridgeKeys();
+            Logger.info("ParkingWalletReturnResume: bridge keys cleared after FAILED", { reservationId });
             if (!cancelled) {
               navigate("/services/parking/summary", {
                 replace: true,
@@ -185,6 +188,8 @@ export function ParkingWalletReturnResume({
           }
         } else {
           Logger.error("ParkingWalletReturnResume", e);
+          await clearWalletParkingPaymentBridgeKeys();
+          Logger.info("ParkingWalletReturnResume: bridge keys cleared after server error", { reservationId });
           if (!cancelled) {
             navigate("/services/parking/summary", {
               replace: true,

--- a/apps/people-app/microapp/src/components/ParkingWalletReturnResume.tsx
+++ b/apps/people-app/microapp/src/components/ParkingWalletReturnResume.tsx
@@ -89,8 +89,12 @@ export function ParkingWalletReturnResume({
 
           if (status === "FAILED") {
             const error = await getLocalDataAsync(PARKING_WALLET_PAYMENT_ERROR_KEY);
-            await clearWalletParkingPaymentBridgeKeys();
-            Logger.info("ParkingWalletReturnResume: bridge keys cleared after FAILED", { reservationId });
+            try {
+              await clearWalletParkingPaymentBridgeKeys();
+              Logger.info("ParkingWalletReturnResume: bridge keys cleared after FAILED", { reservationId });
+            } catch (clearErr) {
+              Logger.error("ParkingWalletReturnResume: bridge key cleanup failed after FAILED", clearErr);
+            }
             if (!cancelled) {
               navigate("/services/parking/summary", {
                 replace: true,
@@ -188,8 +192,12 @@ export function ParkingWalletReturnResume({
           }
         } else {
           Logger.error("ParkingWalletReturnResume", e);
-          await clearWalletParkingPaymentBridgeKeys();
-          Logger.info("ParkingWalletReturnResume: bridge keys cleared after server error", { reservationId });
+          try {
+            await clearWalletParkingPaymentBridgeKeys();
+            Logger.info("ParkingWalletReturnResume: bridge keys cleared after server error", { reservationId });
+          } catch (clearErr) {
+            Logger.error("ParkingWalletReturnResume: bridge key cleanup failed after server error", clearErr);
+          }
           if (!cancelled) {
             navigate("/services/parking/summary", {
               replace: true,

--- a/apps/people-app/microapp/src/pages/ParkingBookingSummaryPage.tsx
+++ b/apps/people-app/microapp/src/pages/ParkingBookingSummaryPage.tsx
@@ -39,6 +39,7 @@ import { formatCoins } from "@/utils/helpers/coins";
 import {
   getParkingPaymentContextState,
   setParkingPaymentContextState,
+  clearParkingPaymentContextState,
 } from "@/utils/parkingStorage";
 import {
   PARKING_WALLET_PAYMENT_ERROR_KEY,
@@ -475,6 +476,9 @@ function ParkingBookingSummaryPage() {
                   onClick={() => {
                     setShowPaymentFailureModal(false);
                     setError(undefined);
+                    clearParkingPaymentContextState();
+                    Logger.info("ParkingBookingSummaryPage: payment context cleared on user dismiss");
+                    navigate("/services/parking");
                   }}
                 >
                   Close


### PR DESCRIPTION
# Description

The "Payment Unsuccessful" modal was getting permanently stuck after a failed wallet payment. every app relaunch re-triggered it with no way out other than tapping the back arrow.

root cause: the failure path in ParkingWalletReturnResume read the FAILED status from native bridge storage but never cleared it. on every fresh mount, it found the same FAILED status and navigated back to the summary page with resumeError. the modal's close button also only cleared react state, leaving both localStorage (reservationId) and bridge storage (status=FAILED) untouched.

changes:
- clear wallet bridge keys after consuming FAILED status in ParkingWalletReturnResume (mirrors what the success path already does)
- also clear bridge keys after a server-side confirm error, so that path doesn't loop either
- close button on the summary page now clears the payment context and navigates to slot selection, so there's no reservationId to re-trigger the resume on next open


Closes https://github.com/wso2-enterprise/wso2-digital-team-project-management/issues/378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery and state management in parking payment scenarios, ensuring temporary payment data is cleared when transactions fail or server errors occur, enabling users to seamlessly retry bookings
  * Enhanced payment failure experience by properly clearing payment state when users dismiss error notifications, ensuring they return to a clean state in the parking services section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->