### PR TITLE
show microapp version at bottom of home screen

### DIFF
--- a/apps/people-app/microapp/src/components/microapp-bridge/index.ts
+++ b/apps/people-app/microapp/src/components/microapp-bridge/index.ts
@@ -39,6 +39,7 @@ declare global {
       // Cross-microapp bridge API (provided by SuperApp).
       requestOpenMicroApp: (targetAppId: string, launchData?: unknown) => void;
       resolveDeviceSafeAreaInsets?: (data: { insets: EdgeInsets }) => void;
+      resolveMicroAppVersion?: (version: string) => void;
     };
     ReactNativeWebView?: {
       postMessage: (message: string) => void;
@@ -235,6 +236,22 @@ export const getLocalDataAsync = async <T = unknown>(key: string) => {
       key: normalizedKey,
     });
   });
+};
+
+export const requestMicroAppVersion = (
+  callback: Callback<string>,
+): void => {
+  if (window.nativebridge) {
+    triggerSuperAppAction(TOPIC.MICRO_APP_VERSION);
+    window.nativebridge.resolveMicroAppVersion = (version) => {
+      callback(version);
+    };
+  } else {
+    Logger.error(
+      ErrorMessages.NATIVE_BRIDGE_NOT_AVAILABLE + " to fetch micro app version",
+    );
+    callback();
+  }
 };
 
 /**

--- a/apps/people-app/microapp/src/components/microapp-bridge/types.ts
+++ b/apps/people-app/microapp/src/components/microapp-bridge/types.ts
@@ -25,6 +25,7 @@ export const TOPIC = {
   NATIVE_LOG: "native_log",
   NAVIGATE_TO_MY_APPS: "close_webview",
   DEVICE_SAFE_AREA_INSETS: "device_safe_area_insets",
+  MICRO_APP_VERSION: "micro_app_version",
 };
 
 export type TopicType = (typeof TOPIC)[keyof typeof TOPIC];

--- a/apps/people-app/microapp/src/pages/HomePage.tsx
+++ b/apps/people-app/microapp/src/pages/HomePage.tsx
@@ -19,17 +19,35 @@ import { services } from "@/constants";
 import { Header } from "@/components/core";
 import { PageTransitionWrapper } from "@/components/shared";
 import { ServiceTile } from "@/components/features/services";
+import { requestMicroAppVersion } from "@/components/microapp-bridge";
+import { useEffect, useState } from "react";
 
 function HomePage({ user: _user }: PageProps) {
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    requestMicroAppVersion((version) => {
+      if (version) setAppVersion(version);
+    });
+  }, []);
+
   return (
     <PageTransitionWrapper type="main">
-      <div className="min-h-screen bg-[#F2F2EF]">
+      <div className="min-h-screen bg-[#F2F2EF] flex flex-col">
         <Header />
-        <main className="px-4 pt-3 flex flex-col gap-4">
+        <main className="px-4 pt-3 pb-4 flex flex-col gap-4 flex-1">
           {services.map((service, index) => (
             <ServiceTile key={index} {...service} />
           ))}
         </main>
+        {appVersion && (
+          <p
+            className="text-center text-xs text-[#9AA0A6]"
+            style={{ paddingBottom: "calc(var(--safe-bottom, 0px) + 12px)" }}
+          >
+            v{appVersion}
+          </p>
+        )}
       </div>
     </PageTransitionWrapper>
   );


### PR DESCRIPTION
adds `micro_app_version` bridge support and displays the version string at the very bottom of the home screen, above the device safe area.

changes:
- added `MICRO_APP_VERSION` topic and `resolveMicroAppVersion` to the bridge types
- exported `requestMicroAppVersion` from the bridge (follows same pattern as `requestDeviceSafeAreaInsets`)
- fetches version on mount in `HomePage`, renders it pinned below the service tiles with safe-area-aware bottom padding