### PR TITLE
fix(careers-app): map upstream-token failures to 502/504 and correct backend port in config template

### DIFF
--- a/apps/careers-app/backend/routers/jobs.py
+++ b/apps/careers-app/backend/routers/jobs.py
@@ -33,8 +33,8 @@ async def list_jobs(
     _user: dict = Depends(get_current_user),
     settings: Settings = Depends(get_settings),
 ):
-    token = await get_vacancy_token(settings)
     try:
+        token = await get_vacancy_token(settings)
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 f"{settings.vacancy_service_base_url}/vacancies/basic-info",
@@ -48,6 +48,9 @@ async def list_jobs(
     except httpx.RequestError as e:
         logger.error("Network error on GET /vacancies/basic-info: %s", e)
         raise HTTPException(status_code=504, detail="Upstream service unreachable")
+    except KeyError as e:
+        logger.error("Malformed token response from upstream on GET /vacancies/basic-info: missing %s", e)
+        raise HTTPException(status_code=502, detail="Invalid response from upstream auth service")
 
 
 @router.get("/org-structure")
@@ -55,8 +58,8 @@ async def get_org_structure(
     _user: dict = Depends(get_current_user),
     settings: Settings = Depends(get_settings),
 ):
-    token = await get_vacancy_token(settings)
     try:
+        token = await get_vacancy_token(settings)
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 f"{settings.vacancy_service_base_url}/org-structure",
@@ -70,6 +73,9 @@ async def get_org_structure(
     except httpx.RequestError as e:
         logger.error("Network error on GET /org-structure: %s", e)
         raise HTTPException(status_code=504, detail="Upstream service unreachable")
+    except KeyError as e:
+        logger.error("Malformed token response from upstream on GET /org-structure: missing %s", e)
+        raise HTTPException(status_code=502, detail="Invalid response from upstream auth service")
 
 
 @router.get("/{job_id}")
@@ -78,8 +84,8 @@ async def get_job(
     _user: dict = Depends(get_current_user),
     settings: Settings = Depends(get_settings),
 ):
-    token = await get_vacancy_token(settings)
     try:
+        token = await get_vacancy_token(settings)
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 f"{settings.vacancy_service_base_url}/vacancies/{job_id}",
@@ -97,3 +103,6 @@ async def get_job(
     except httpx.RequestError as e:
         logger.error("Network error on GET /vacancies/%s: %s", job_id, e)
         raise HTTPException(status_code=504, detail="Upstream service unreachable")
+    except KeyError as e:
+        logger.error("Malformed token response from upstream on GET /vacancies/%s: missing %s", job_id, e)
+        raise HTTPException(status_code=502, detail="Invalid response from upstream auth service")

--- a/apps/careers-app/webapp/public/config.js.local
+++ b/apps/careers-app/webapp/public/config.js.local
@@ -6,5 +6,5 @@ window.config = {
   ASGARDEO_REVOKE_ENDPOINT: "https://api.asgardeo.io/t/<org>/oauth2/revoke",
   AUTH_SIGN_IN_REDIRECT_URL: "http://localhost:3000",
   AUTH_SIGN_OUT_REDIRECT_URL: "http://localhost:3000",
-  CAREERS_BACKEND_BASE_URL: "http://localhost:9090",
+  CAREERS_BACKEND_BASE_URL: "http://localhost:8080",
 };


### PR DESCRIPTION
## Purpose
Fixes two issues in the careers-app:

1. **Backend - jobs router (`apps/careers-app/backend/routers/jobs.py`):** all three handlers  called `get_vacancy_token(settings)` *outside* the `try` block. A failure obtaining the upstream token (rejected client credentials, unreachable auth server, or a malformed token response) escaped the `httpx` handlers and surfaced as an opaque `500`, even though the same upstream failure during the jobs fetch correctly returns `502`/`504`. The error contract was therefore inconsistent for the same root cause.

2. **Frontend config template (`apps/careers-app/webapp/public/config.js.local`):** `CAREERS_BACKEND_BASE_URL` pointed at `http://localhost:9090` (the Ballerina apps' port), but the careers backend runs on `8080` (`main.py`). Anyone copying the template to `config.js` got connection failures on every API call until they noticed.

## Goals
- Map upstream-token failures to the same `502`/`504` contract already used for the upstream data fetch, so callers get a truthful status code instead of `500`.
- Make the config template point new contributors at the correct backend port out of the box.

## Approach
**Backend** (`apps/careers-app/backend/routers/jobs.py`):
- Moved `token = await get_vacancy_token(settings)` inside the existing `try` block in all three handlers (`list_jobs`, `get_org_structure`, `get_job`), so a token-fetch `httpx.HTTPStatusError` → `502` and `httpx.RequestError` → `504`, just like the data fetch.
- Added an `except KeyError` → `502` ("Invalid response from upstream auth service") to cover a malformed token response missing `access_token`/`expires_in`.
- In `get_job`, the existing `except HTTPException: raise` remains first, so the explicit `404` still passes through untouched.

**Config template** (`apps/careers-app/webapp/public/config.js.local`):
- Changed `CAREERS_BACKEND_BASE_URL` from `http://localhost:9090` to `http://localhost:8080` to match the port the backend actually listens on.

## User stories
N/A


## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Python 3.12
 
## Learning
N/A