### PR TITLE
Visitor App - Add computeIdHash function and improve contact info privacy

### DIFF
--- a/apps/visitor-app/backend/constants.bal
+++ b/apps/visitor-app/backend/constants.bal
@@ -14,3 +14,4 @@
 // specific language governing permissions and limitations
 // under the License. 
 public const USER_INFO_HEADER_NOT_FOUND_ERROR = "User information header not found!";
+public const SANITIZED_VALUE = "SANITIZED";

--- a/apps/visitor-app/backend/modules/database/utils.bal
+++ b/apps/visitor-app/backend/modules/database/utils.bal
@@ -96,6 +96,14 @@ public isolated function toHexString(byte[] data) returns string {
     return result;
 }
 
+# Compute the SHA-256 id hash of an email or contact number, matching the webapp's hashing scheme
+# (trim + lowercase + SHA-256 hex) so a stored value can be checked against a caller-supplied idHash.
+#
+# + value - Email or contact number to hash
+# + return - Hex-encoded SHA-256 hash
+public isolated function computeIdHash(string value) returns string
+    => toHexString(crypto:hashSha256(value.trim().toLowerAscii().toBytes()));
+
 # Decrypt the input format using AES-256-CBC.
 #
 # + value - Input string in the format "ivHex:encryptedHex"

--- a/apps/visitor-app/backend/service.bal
+++ b/apps/visitor-app/backend/service.bal
@@ -173,6 +173,14 @@ service http:InterceptableService / on new http:Listener(9090) {
             visitor.email = ();
         }
 
+        // Hide audit metadata from external users.
+        if authorization:checkPermissions([authorization:authorizedRoles.EXTERNAL_USER_ROLE], invokerInfo.groups) {
+            visitor.createdBy = SANITIZED_VALUE;
+            visitor.createdOn = SANITIZED_VALUE;
+            visitor.updatedBy = SANITIZED_VALUE;
+            visitor.updatedOn = SANITIZED_VALUE;
+        }
+
         return visitor;
     }
 

--- a/apps/visitor-app/backend/service.bal
+++ b/apps/visitor-app/backend/service.bal
@@ -159,6 +159,20 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        // Only return the identifier that was actually searched for: hide the contact number
+        // when the caller searched by email, and hide the email when the caller searched by
+        // contact number, by re-deriving each hash from the stored value and comparing it to
+        // the requested idHash.
+        string? storedEmail = visitor.email;
+        string? storedContactNumber = visitor.contactNumber;
+
+        if storedEmail is string && database:computeIdHash(storedEmail) == idHash {
+            visitor.contactNumber = ();
+        }
+        if storedContactNumber is string && database:computeIdHash(storedContactNumber) == idHash {
+            visitor.email = ();
+        }
+
         return visitor;
     }
 


### PR DESCRIPTION
This pull request introduces important privacy and security improvements to the visitor API. The main changes are focused on ensuring that only the searched-for identifier is returned, sensitive audit metadata is hidden from external users, and a utility function is added for consistent hashing of identifiers.

**Privacy and security improvements:**

* In the visitor lookup endpoint (`service.bal`), only the identifier requested by the caller (email or contact number) is returned; the other is hidden by comparing hashes, preventing unnecessary exposure of user data.
* Audit metadata fields (`createdBy`, `createdOn`, `updatedBy`, `updatedOn`) are now replaced with a sanitized value for external users, further protecting sensitive information.
* Added a new constant `SANITIZED_VALUE` in `constants.bal` to standardize the value used for hiding sensitive data.

**Hashing utility:**

* Introduced a new function `computeIdHash` in `utils.bal` to compute a SHA-256 hash of an email or contact number, matching the webapp’s hashing scheme. This ensures consistent identifier handling and comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Visitor searches now support consistent identifier matching regardless of capitalization or surrounding spaces.
  - Search results display only the identifier used to locate the visitor.
  - External users now see sanitized audit metadata in visitor details.

- **Privacy & Security**
  - Sensitive visitor information is limited based on the lookup identifier and caller access level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->