### PR TITLE
Visitor App - Visitor App - Protect visitor PII in lookup responses and allow flexible email/contact input

### DIFF
--- a/apps/visitor-app/backend/service.bal
+++ b/apps/visitor-app/backend/service.bal
@@ -209,14 +209,6 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        if payload.email is string && payload.contactNumber is string {
-            return <http:BadRequest>{
-                body: {
-                    message: "Only one of email or contact number should be provided!"
-                }
-            };
-        }
-
         error? visitorError = database:addVisitor(payload, invokerInfo.email);
         if visitorError is error {
             string customError = "Error occurred while adding visitor!";

--- a/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
+++ b/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
@@ -394,7 +394,8 @@ function CreateVisit() {
       if (fetchVisitor.fulfilled.match(action)) {
         let countryCode = "+94";
         let nationalNumber = "";
-        const raw = source === "email" ? "" : action.payload.contactNumber || "";
+        const raw =
+          source === "email" ? "" : action.payload.contactNumber || "";
         if (raw) {
           try {
             const parsed = phoneUtil.parseAndKeepRawInput(raw);
@@ -928,6 +929,15 @@ function CreateVisit() {
                       )}
                   </Box>
 
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: "block", mb: 1 }}
+                  >
+                    Only one is required — enter an email address or a contact
+                    number.
+                  </Typography>
+
                   <Grid container spacing={3}>
                     <Grid item xs={12} md={6}>
                       <TextField
@@ -1013,10 +1023,7 @@ function CreateVisit() {
                             600,
                           );
                         }}
-                        disabled={
-                          visitor.status === VisitorStatus.Completed ||
-                          !!visitor.contactNumber?.trim()
-                        }
+                        disabled={visitor.status === VisitorStatus.Completed}
                         error={
                           (visitorTouched?.emailAddress &&
                             !!visitorErrors?.emailAddress) ||
@@ -1092,10 +1099,7 @@ function CreateVisit() {
                         }}
                         defaultCountry="LK"
                         forceCallingCode
-                        disabled={
-                          visitor.status === VisitorStatus.Completed ||
-                          !!visitor.emailAddress?.trim()
-                        }
+                        disabled={visitor.status === VisitorStatus.Completed}
                         error={
                           visitorTouched?.contactNumber &&
                           !!visitorErrors?.contactNumber


### PR DESCRIPTION
This pull request updates the visitor creation flow to improve user experience and validation around providing email and contact number information. The main changes remove a backend restriction and clarify frontend guidance, ensuring only one of email or contact number is required, not both.

**Backend validation changes:**

* Removed the backend check in `service.bal` that returned a bad request if both `email` and `contactNumber` were provided, allowing the frontend to handle this validation instead.

**Frontend UI and logic improvements:**

* Added a user-facing message in `createVisit.tsx` to clarify that only one of email or contact number is required when creating a visit.
* Updated form field disabling logic so that the email and contact number fields are only disabled when the visitor's status is `Completed`, not when the other field is filled. This allows users to correct their input as needed. [[1]](diffhunk://#diff-95edfbbc47ab934b70fe81d405ad313cbb1d8d44492bf799a088d181114b644dL1016-R1026) [[2]](diffhunk://#diff-95edfbbc47ab934b70fe81d405ad313cbb1d8d44492bf799a088d181114b644dL1095-R1102)

**Code cleanup:**

* Minor formatting adjustment for better readability in variable assignment for contact number extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visitor registration now requires at least one contact method: an email address or contact number.
  * Users can provide both an email address and contact number when creating a visit.
  * Added guidance to the visitor form clarifying that only one contact method is required.

* **Bug Fixes**
  * Updated visitor creation validation to match the form’s contact information requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->