### PR TITLE
Visitor App - Fix duplicate visitor lookup trigger and enforce unique contact number in visitor form

### DIFF
--- a/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
+++ b/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
@@ -956,6 +956,9 @@ function CreateVisit() {
                             extractedEmail,
                           );
 
+                          if (formik.values.visitors[idx].contactNumber)
+                            return;
+
                           if (
                             visitor.status === VisitorStatus.Draft &&
                             extractedEmail &&
@@ -988,6 +991,9 @@ function CreateVisit() {
                             `visitors.${idx}.emailAddress`,
                             email,
                           );
+
+                          if (formik.values.visitors[idx].contactNumber)
+                            return;
 
                           if (visitorEmailDebounceRefs.current[idx]) {
                             clearTimeout(

--- a/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
+++ b/apps/visitor-app/webapp/src/view/employee/panel/createVisit.tsx
@@ -535,6 +535,20 @@ function CreateVisit() {
             }
           })
           .test(
+            "unique-contact",
+            "Contact number must be unique",
+            function (value) {
+              const visitors = this.options.context?.visitors || [];
+              if (!value) return true;
+              const normalized = value.replace(/\D/g, "");
+              return (
+                visitors.filter(
+                  (v: any) => v.contactNumber?.replace(/\D/g, "") === normalized,
+                ).length === 1
+              );
+            },
+          )
+          .test(
             "contact-or-email-required",
             "Email address or contact number is required",
             function (value) {


### PR DESCRIPTION
This pull request enhances validation and logic related to visitor contact numbers in the `CreateVisit` panel. The main improvements ensure that each visitor's contact number is unique and streamline the flow when a contact number is already provided.

**Validation Enhancements:**

* Added a new Yup `.test` called `"unique-contact"` to the contact number field, ensuring that each visitor's contact number is unique (ignoring formatting differences) among all visitors in the form.

**Logic Improvements:**

* Updated logic to immediately return from certain handlers if a contact number is already present for a visitor, preventing unnecessary processing when the contact number exists. [[1]](diffhunk://#diff-95edfbbc47ab934b70fe81d405ad313cbb1d8d44492bf799a088d181114b644dR973-R975) [[2]](diffhunk://#diff-95edfbbc47ab934b70fe81d405ad313cbb1d8d44492bf799a088d181114b644dR1009-R1011)