### PR TITLE
[People App] [Backend] Fix designation composition order

### DIFF
--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -28,10 +28,10 @@ isolated function getEmployeeBasicInfoQuery(string email) returns sql:Parameteri
         e.employee_thumbnail,
         CONCAT(
             d.designation,
-            CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
-                THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END,
             CASE WHEN NULLIF(TRIM(e.secondary_job_title), '') IS NOT NULL
-                THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END
+                THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END,
+            CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
+                THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END
         ) AS designation
     FROM employee e
         INNER JOIN designation d ON e.designation_id = d.id
@@ -111,10 +111,10 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
         d.career_function_id AS careerFunctionId,
         CONCAT(
             d.designation,
-            CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
-                THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END,
             CASE WHEN NULLIF(TRIM(e.secondary_job_title), '') IS NOT NULL
-                THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END
+                THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END,
+            CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
+                THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END
         ) AS designation,
         e.designation_id AS designationId,
         d.job_band AS jobBand,
@@ -197,10 +197,10 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
             d.career_function_id AS careerFunctionId,
             CONCAT(
                 d.designation,
-                CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
-                    THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END,
                 CASE WHEN NULLIF(TRIM(e.secondary_job_title), '') IS NOT NULL
-                    THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END
+                    THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END,
+                CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
+                    THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END
             ) AS designation,
             e.designation_id AS designationId,
             d.job_band AS jobBand,
@@ -442,10 +442,10 @@ isolated function getContinuousServiceRecordQuery(string workEmail) returns sql:
         COALESCE(eam.additionalManagerEmails, '') AS additionalManagerEmails,
         CONCAT(
             d.designation,
-            CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
-                THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END,
             CASE WHEN NULLIF(TRIM(e.secondary_job_title), '') IS NOT NULL
-                THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END
+                THEN CONCAT(' ', TRIM(e.secondary_job_title)) ELSE '' END,
+            CASE WHEN NULLIF(TRIM(e.job_role), '') IS NOT NULL
+                THEN CONCAT(' & ', TRIM(e.job_role)) ELSE '' END
         ) AS designation,
         e.secondary_job_title AS secondaryJobTitle,
         o.name AS office,


### PR DESCRIPTION
## Purpose

The display designation was composed as `<Designation> & <Job Role> <Secondary Job Title>`, which places the secondary job title after the job role — e.g. `Senior Technical Lead & Head of Engineering - Integration II`.

This changes the order to `<Designation> <Secondary Job Title> & <Job Role>` so the secondary title stays attached to the designation it qualifies — e.g. `Senior Technical Lead II & Head of Engineering - Integration`.

## Approach

Swapped the secondary-job-title and job-role `CASE` segments in the `CONCAT` expression in all four queries that compose the designation in `backend/modules/database/db_queries.bal` (employee basic info, all employees basic info, employee details, and the employees list). The empty/whitespace handling for both fields is unchanged, and the frontend needs no changes since it displays the backend-composed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering of employee designation details so secondary job titles appear before job roles where applicable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->