### PR TITLE
Visitor App - feat: add reception user email configuration and authorization handling

### DIFF
--- a/apps/visitor-app/backend/Config.toml.local
+++ b/apps/visitor-app/backend/Config.toml.local
@@ -2,7 +2,7 @@
 webAppUrl = ""
 
 [visitor.authorization]
-AUTHORIZED_CLIENT_ID = ""
+receptionUserEmails = [""]
 
 [visitor.authorization.authorizedRoles]
 ADMIN_ROLE = ""

--- a/apps/visitor-app/backend/modules/authorization/authorization.bal
+++ b/apps/visitor-app/backend/modules/authorization/authorization.bal
@@ -20,6 +20,11 @@ import ballerina/log;
 
 public configurable AppRoles authorizedRoles = ?;
 
+# Emails of shared/non-employee accounts (e.g. reception desks) that are authorized via
+# authorizedRoles but are not present in the employee management system, so employee lookups
+# for these emails should be bypassed.
+public configurable string[] receptionUserEmails = [];
+
 # To handle authorization for each resource function invocation.
 public isolated service class JwtInterceptor {
 

--- a/apps/visitor-app/backend/service.bal
+++ b/apps/visitor-app/backend/service.bal
@@ -82,6 +82,16 @@ service http:InterceptableService / on new http:Listener(9090) {
                 jobRole: "External User",
                 employeeId: "N/A"
             };
+        } else if authorization:receptionUserEmails.indexOf(userInfo.email) !is () {
+            // Shared reception accounts are authorized via roles but are not real employees,
+            // so bypass fetching employee details and return with basic user info.
+            user = {
+                firstName: "WSO2",
+                lastName: "Reception",
+                workEmail: userInfo.email,
+                jobRole: "Reception",
+                employeeId: "N/A"
+            };
         } else { // For internal users, fetch employee details from the user store.
             people:Employee|error? employee = people:fetchEmployee(userInfo.email);
             if employee is error {


### PR DESCRIPTION
This pull request updates the visitor app backend to support shared/non-employee reception user accounts that are authorized via roles but do not exist in the employee management system. The main changes add a new configuration for specifying these reception user emails and update the authorization logic to handle them appropriately.

**Reception user account support:**

* Added a new `receptionUserEmails` configuration in `Config.toml.local` and the `authorization.bal` module to specify authorized shared/non-employee accounts (e.g., reception desks) that should bypass employee lookup. [[1]](diffhunk://#diff-23db38e45981c9407557d7e435e43924f5db9dc5f7d1fe84508b8043ab62a486L5-R5) [[2]](diffhunk://#diff-ccedd8aa12851173b382f6772cf1fa0ecdc286c10a2689e3521d6aee34bc5cdbR23-R27)
* Updated the user info retrieval logic in `service.bal` to check if the user email is in `receptionUserEmails` and, if so, bypass employee lookup and return basic user info for reception accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shared reception accounts through configurable email authorization.
  * Reception accounts can now access authorized features without employee-directory lookups.
  * Reception users receive consistent profile details identifying them as reception staff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->