### PR TITLE
[People App] Employees view follow-ups, office query fix, and rows-per-page persistence

### DIFF
--- a/apps/people-app/backend/Dependencies.toml
+++ b/apps/people-app/backend/Dependencies.toml
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -345,7 +345,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "confluent.cregistry"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1217,11 +1217,10 @@ isolated function getCompaniesQuery() returns sql:ParameterizedQuery =>
 # + return - Offices query
 isolated function getOfficesQuery(int? companyId = ()) returns sql:ParameterizedQuery {
     sql:ParameterizedQuery query = `
-        SELECT 
+        SELECT
             id,
             name,
-            location,
-            working_locations
+            location
         FROM office`;
     if companyId is int {
         query = sql:queryConcat(query, ` WHERE company_id = ${companyId}`);

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -608,9 +608,6 @@ public type Office record {|
     string name;
     # Office location
     string location;
-    # Working locations
-    @sql:Column {name: "working_locations"}
-    json workingLocations;
 |};
 
 # Employment type.

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -158,7 +158,6 @@ CREATE TABLE `office` (
   `company_id` INT NOT NULL,
   `name` VARCHAR(255) NOT NULL,
   `location` VARCHAR(255) NOT NULL,
-  `working_locations` JSON NOT NULL,
   `is_active` TINYINT(1) NOT NULL DEFAULT 1,
   `created_by` VARCHAR(254) NOT NULL,
   `created_on` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),

--- a/apps/people-app/webapp/src/config/constant.ts
+++ b/apps/people-app/webapp/src/config/constant.ts
@@ -39,6 +39,7 @@ export const SERVICE_DESK_PRIVILEGE = 991;
 export const DEFAULT_LIMIT_VALUE = 10;
 export const DEFAULT_OFFSET_VALUE = 0;
 export const PAGE_SIZE_OPTIONS = [5, 10, 15, 20, 25];
+export const ROWS_PER_PAGE_STORAGE_KEY = "people-app-rows-per-page";
 
 export const SEARCH_REGEX = /^[\p{L}\p{M}0-9\s@._'+-]*$/u;
 export const SEARCH_MAX_LENGTH = 100;

--- a/apps/people-app/webapp/src/slices/organizationSlice/organization.ts
+++ b/apps/people-app/webapp/src/slices/organizationSlice/organization.ts
@@ -68,7 +68,6 @@ export interface Office {
   id: number;
   name: string;
   location: string;
-  workingLocations: string[];
 }
 
 export interface EmploymentType {
@@ -370,9 +369,6 @@ export const fetchOffices = createAsyncThunk(
         id: office.id,
         name: office.name,
         location: office.location,
-        workingLocations: Array.isArray(office.workingLocations)
-          ? office.workingLocations
-          : [],
       }));
       return offices;
     } catch (error: any) {

--- a/apps/people-app/webapp/src/utils/utils.ts
+++ b/apps/people-app/webapp/src/utils/utils.ts
@@ -15,7 +15,12 @@
 // under the License.
 
 import { ServiceLength } from "@src/types/types";
-import { DATE_FMT } from "@config/constant";
+import {
+  DATE_FMT,
+  DEFAULT_LIMIT_VALUE,
+  PAGE_SIZE_OPTIONS,
+  ROWS_PER_PAGE_STORAGE_KEY,
+} from "@config/constant";
 import { differenceInMonths } from "date-fns/differenceInMonths";
 import { differenceInYears } from "date-fns/differenceInYears";
 import { isAfter } from "date-fns/isAfter";
@@ -232,3 +237,14 @@ export const countCsvDataRows = (rows: string[][]): number => {
 // Strips the Byte Order Mark (BOM) from the beginning of a string if it exists.
 export const stripBom = (text: string): string =>
   text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+
+// Returns the user's persisted rows-per-page selection, shared across all tables.
+export const getPersistedPageSize = (): number => {
+  const stored = Number(localStorage.getItem(ROWS_PER_PAGE_STORAGE_KEY));
+  return PAGE_SIZE_OPTIONS.includes(stored) ? stored : DEFAULT_LIMIT_VALUE;
+};
+
+// Persists the user's rows-per-page selection, shared across all tables.
+export const persistPageSize = (pageSize: number): void => {
+  localStorage.setItem(ROWS_PER_PAGE_STORAGE_KEY, String(pageSize));
+};

--- a/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
@@ -37,10 +37,10 @@ export default function EmployeesTable() {
   const employeeState = useAppSelector((state) => state.employee);
   const navigate = useNavigate();
 
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>(() => ({
     page: 0,
     pageSize: getPersistedPageSize(),
-  });
+  }));
 
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
 

--- a/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/employeesTable/EmployeesTable.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { DEFAULT_LIMIT_VALUE, PAGE_SIZE_OPTIONS } from "@config/constant";
+import { PAGE_SIZE_OPTIONS } from "@config/constant";
 import { alpha, Avatar, Box, Chip, Skeleton, Tooltip, useTheme } from "@mui/material";
 import { DataGrid, GridColDef, GridPaginationModel, GridRenderCellParams, GridSortItem, GridSortModel } from "@mui/x-data-grid";
 import {
@@ -29,7 +29,7 @@ import { State } from "@src/types/types";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { SearchForm } from "../searchForm/SearchForm";
-import { formatDate, getEmployeeStatusColor } from "@utils/utils";
+import { formatDate, getEmployeeStatusColor, getPersistedPageSize, persistPageSize } from "@utils/utils";
 
 export default function EmployeesTable() {
   const theme = useTheme();
@@ -39,7 +39,7 @@ export default function EmployeesTable() {
 
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
-    pageSize: DEFAULT_LIMIT_VALUE,
+    pageSize: getPersistedPageSize(),
   });
 
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
@@ -366,6 +366,7 @@ export default function EmployeesTable() {
           paginationModel={paginationModel}
           pageSizeOptions={PAGE_SIZE_OPTIONS}
           onPaginationModelChange={(model) => {
+            if (model.pageSize !== paginationModel.pageSize) persistPageSize(model.pageSize);
             setPaginationModel({
               page: model.page,
               pageSize: model.pageSize,

--- a/apps/people-app/webapp/src/view/employees/employeesView/searchForm/RemovableFilterChip.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/searchForm/RemovableFilterChip.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { alpha, Chip, useTheme } from "@mui/material";
+
+type RemovableFilterChipProps = {
+  label: string;
+  onDelete: () => void;
+};
+
+/**
+ * A styled, removable chip used to display a single selected value of a
+ * multi-select filter (e.g. an employment type or employee status) in the
+ * active-filters row. Clicking the delete icon invokes `onDelete`.
+ */
+export function RemovableFilterChip({ label, onDelete }: RemovableFilterChipProps) {
+  const theme = useTheme();
+  const accentColor = theme.palette.secondary.contrastText;
+  return (
+    <Chip
+      label={label}
+      variant="outlined"
+      onDelete={onDelete}
+      sx={{
+        height: "32px",
+        borderRadius: "50px",
+        fontSize: "12px",
+        fontWeight: 600,
+        color: theme.palette.mode === "dark" ? theme.palette.grey[100] : theme.palette.grey[800],
+        backgroundColor: alpha(accentColor, theme.palette.mode === "dark" ? 0.12 : 0.06),
+        border: `1.5px solid ${accentColor}`,
+        "& .MuiChip-deleteIcon": {
+          color: theme.palette.text.disabled,
+          "&:hover": { color: theme.palette.error.main },
+        },
+      }}
+    />
+  );
+}
+
+/**
+ * Remove a single value from a multi-select filter array, returning `undefined`
+ * when the array becomes empty so the filter is cleared rather than sent empty.
+ */
+export function dropFilterValue<T>(values: T[], value: T): T[] | undefined {
+  const next = values.filter((v) => v !== value);
+  return next.length ? next : undefined;
+}

--- a/apps/people-app/webapp/src/view/employees/employeesView/searchForm/SearchForm.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/searchForm/SearchForm.tsx
@@ -72,6 +72,7 @@ import { State } from "@src/types/types";
 import { toSentenceCase, sortAndFormatOptions } from "@utils/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FilterChipSelect, FilterChipSelectProps } from "./FilterChipSelect";
+import { RemovableFilterChip, dropFilterValue } from "./RemovableFilterChip";
 import { FilterDrawer } from "./FilterDrawer";
 
 type ChipMeta<K extends string, T> = { kind: K } & FilterChipSelectProps<T>;
@@ -204,6 +205,12 @@ export function SearchForm() {
       excludeFutureStartDate,
     } = filters;
 
+    // Baseline (Active + Marked leaver, exclude future joiners) is the default — not an active filter.
+    const baselineStatuses = [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver];
+    const isBaselineStatuses =
+      (employeeStatuses?.length ?? 0) === baselineStatuses.length &&
+      baselineStatuses.every((status) => employeeStatuses?.includes(status));
+
     return Boolean(
       businessUnitId ||
       teamId ||
@@ -216,8 +223,8 @@ export function SearchForm() {
       managerEmail ||
       companyId ||
       officeId ||
-      employeeStatuses?.length ||
-      excludeFutureStartDate,
+      (!isBaselineStatuses && employeeStatuses?.length) ||
+      excludeFutureStartDate === false,
     );
   }
 
@@ -238,6 +245,13 @@ export function SearchForm() {
       employeeStatuses,
       excludeFutureStartDate,
     } = filterPayload.filters;
+    // Baseline (Active + Marked leaver, exclude future joiners) is the default — don't count it.
+    const baselineStatuses = [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver];
+    const isBaselineStatuses =
+      (employeeStatuses?.length ?? 0) === baselineStatuses.length &&
+      baselineStatuses.every((status) => employeeStatuses?.includes(status));
+    const statusCount = isBaselineStatuses ? 0 : (employeeStatuses?.length ?? 0);
+    const includeFutureStartDateFilter = excludeFutureStartDate === false;
     return [
       businessUnitId,
       teamId,
@@ -250,29 +264,13 @@ export function SearchForm() {
       managerEmail,
       companyId,
       officeId,
-      employeeStatuses?.length,
-      excludeFutureStartDate,
+      statusCount || undefined,
+      includeFutureStartDateFilter || undefined,
     ].filter(Boolean).length;
   }, [filterPayload.filters]);
 
   // Check if any of the filters are active
   const active = activeFilterCount > 0;
-
-  // Shared style for the multi-select filter chips (Employment Type, Status).
-  const accentColor = theme.palette.secondary.contrastText;
-  const multiFilterChipSx = {
-    height: "32px",
-    borderRadius: "50px",
-    fontSize: "12px",
-    fontWeight: 600,
-    color: theme.palette.mode === "dark" ? theme.palette.grey[100] : theme.palette.grey[800],
-    backgroundColor: alpha(accentColor, theme.palette.mode === "dark" ? 0.12 : 0.06),
-    border: `1.5px solid ${accentColor}`,
-    "& .MuiChip-deleteIcon": {
-      color: theme.palette.text.disabled,
-      "&:hover": { color: theme.palette.error.main },
-    },
-  };
 
   // Derive manager emails
   const managerEmails = useMemo(() => {
@@ -822,36 +820,36 @@ export function SearchForm() {
                 const employmentType = employmentTypes.find((et) => et.id === id);
                 if (!employmentType) return null;
                 return (
-                  <Chip
+                  <RemovableFilterChip
                     key={`employmentType-${id}`}
                     label={`Employment Type: ${toSentenceCase(employmentType.name)}`}
-                    variant="outlined"
-                    onDelete={() => {
-                      const next = (filterPayload.filters.employmentTypeIds ?? []).filter(
-                        (x) => x !== id,
-                      );
+                    onDelete={() =>
                       updateSearchPayload({
-                        filters: { employmentTypeIds: next.length ? next : undefined },
-                      });
-                    }}
-                    sx={multiFilterChipSx}
+                        filters: {
+                          employmentTypeIds: dropFilterValue(
+                            filterPayload.filters.employmentTypeIds ?? [],
+                            id,
+                          ),
+                        },
+                      })
+                    }
                   />
                 );
               })}
               {(filterPayload.filters.employeeStatuses ?? []).map((status) => (
-                <Chip
+                <RemovableFilterChip
                   key={`employeeStatus-${status}`}
                   label={`Status: ${toSentenceCase(status)}`}
-                  variant="outlined"
-                  onDelete={() => {
-                    const next = (filterPayload.filters.employeeStatuses ?? []).filter(
-                      (s) => s !== status,
-                    );
+                  onDelete={() =>
                     updateSearchPayload({
-                      filters: { employeeStatuses: next.length ? next : undefined },
-                    });
-                  }}
-                  sx={multiFilterChipSx}
+                      filters: {
+                        employeeStatuses: dropFilterValue(
+                          filterPayload.filters.employeeStatuses ?? [],
+                          status,
+                        ),
+                      },
+                    })
+                  }
                 />
               ))}
               {hasActiveFilters && (

--- a/apps/people-app/webapp/src/view/employees/employeesView/searchForm/SearchForm.tsx
+++ b/apps/people-app/webapp/src/view/employees/employeesView/searchForm/SearchForm.tsx
@@ -90,6 +90,12 @@ type ChipConfig =
   | ChipMeta<"office", Office>
   | ChipMeta<"gender", string>;
 
+// Baseline (Active + Marked leaver) is the default status selection — not an active filter.
+const BASELINE_STATUSES = [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver];
+const isBaselineStatuses = (employeeStatuses?: EmployeeStatus[]): boolean =>
+  (employeeStatuses?.length ?? 0) === BASELINE_STATUSES.length &&
+  BASELINE_STATUSES.every((status) => employeeStatuses?.includes(status));
+
 export function SearchForm() {
   const dispatch = useAppDispatch();
   const theme = useTheme();
@@ -186,48 +192,6 @@ export function SearchForm() {
     );
   };
 
-  function hasAnyActiveFilters(
-    filters: EmployeeSearchPayload["filters"],
-  ): boolean {
-    const {
-      businessUnitId,
-      teamId,
-      subTeamId,
-      unitId,
-      careerFunctionId,
-      designationId,
-      gender,
-      employmentTypeIds,
-      managerEmail,
-      companyId,
-      officeId,
-      employeeStatuses,
-      excludeFutureStartDate,
-    } = filters;
-
-    // Baseline (Active + Marked leaver, exclude future joiners) is the default — not an active filter.
-    const baselineStatuses = [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver];
-    const isBaselineStatuses =
-      (employeeStatuses?.length ?? 0) === baselineStatuses.length &&
-      baselineStatuses.every((status) => employeeStatuses?.includes(status));
-
-    return Boolean(
-      businessUnitId ||
-      teamId ||
-      subTeamId ||
-      unitId ||
-      careerFunctionId ||
-      gender ||
-      designationId ||
-      employmentTypeIds?.length ||
-      managerEmail ||
-      companyId ||
-      officeId ||
-      (!isBaselineStatuses && employeeStatuses?.length) ||
-      excludeFutureStartDate === false,
-    );
-  }
-
   // Count how many filters are active
   const activeFilterCount = useMemo(() => {
     const {
@@ -245,12 +209,9 @@ export function SearchForm() {
       employeeStatuses,
       excludeFutureStartDate,
     } = filterPayload.filters;
-    // Baseline (Active + Marked leaver, exclude future joiners) is the default — don't count it.
-    const baselineStatuses = [EmployeeStatus.Active, EmployeeStatus.MarkedLeaver];
-    const isBaselineStatuses =
-      (employeeStatuses?.length ?? 0) === baselineStatuses.length &&
-      baselineStatuses.every((status) => employeeStatuses?.includes(status));
-    const statusCount = isBaselineStatuses ? 0 : (employeeStatuses?.length ?? 0);
+    const statusCount = isBaselineStatuses(employeeStatuses)
+      ? 0
+      : (employeeStatuses?.length ?? 0);
     const includeFutureStartDateFilter = excludeFutureStartDate === false;
     return [
       businessUnitId,
@@ -441,13 +402,9 @@ export function SearchForm() {
     throw new Error("Unhandled chip kind");
   };
 
-  const hasActiveFilters = useMemo(() => {
-    return hasAnyActiveFilters(filterPayload.filters);
-  }, [filterPayload.filters]);
-
   const hasSearchString = !!employeeState.employeeFilter.searchString?.trim();
   const showFilteredCard =
-    (employeeState.filterAppliedOnce && hasActiveFilters) || hasSearchString;
+    (employeeState.filterAppliedOnce && active) || hasSearchString;
 
   const isLoading: boolean =
     employeeState.filteredEmployeesResponseState === State.loading;
@@ -852,7 +809,7 @@ export function SearchForm() {
                   }
                 />
               ))}
-              {hasActiveFilters && (
+              {active && (
                 <Button
                   variant="text"
                   onClick={clearAll}

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { DEFAULT_LIMIT_VALUE, PAGE_SIZE_OPTIONS } from "@config/constant";
+import { PAGE_SIZE_OPTIONS } from "@config/constant";
 import { alpha, Avatar, Box, Chip, Skeleton, Tooltip, useTheme } from "@mui/material";
 import {
   DataGrid,
@@ -35,7 +35,7 @@ import { State } from "@src/types/types";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { MyTeamSearchForm } from "./MyTeamSearchForm";
-import { getEmployeeStatusColor } from "@utils/utils";
+import { getEmployeeStatusColor, getPersistedPageSize, persistPageSize } from "@utils/utils";
 
 export default function MyTeamTable() {
   const theme = useTheme();
@@ -45,7 +45,7 @@ export default function MyTeamTable() {
 
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
-    pageSize: DEFAULT_LIMIT_VALUE,
+    pageSize: getPersistedPageSize(),
   });
 
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
@@ -312,7 +312,10 @@ export default function MyTeamTable() {
           loading={isLoading}
           paginationModel={paginationModel}
           pageSizeOptions={PAGE_SIZE_OPTIONS}
-          onPaginationModelChange={(model) => setPaginationModel({ page: model.page, pageSize: model.pageSize })}
+          onPaginationModelChange={(model) => {
+            if (model.pageSize !== paginationModel.pageSize) persistPageSize(model.pageSize);
+            setPaginationModel({ page: model.page, pageSize: model.pageSize });
+          }}
           sortingMode="server"
           sortModel={sortModel}
           onSortModelChange={(model) => {

--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
@@ -43,10 +43,10 @@ export default function MyTeamTable() {
   const employeeState = useAppSelector((state) => state.employee);
   const navigate = useNavigate();
 
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>(() => ({
     page: 0,
     pageSize: getPersistedPageSize(),
-  });
+  }));
 
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
 

--- a/apps/people-app/webapp/src/view/masterData/EntityTab.tsx
+++ b/apps/people-app/webapp/src/view/masterData/EntityTab.tsx
@@ -36,7 +36,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import SearchIcon from "@mui/icons-material/Search";
 import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { useCallback, useMemo, useState } from "react";
-import { DEFAULT_LIMIT_VALUE, PAGE_SIZE_OPTIONS } from "@config/constant";
+import { PAGE_SIZE_OPTIONS } from "@config/constant";
 import { getPersistedPageSize, persistPageSize } from "@utils/utils";
 import {
   CreateEntityPayload,
@@ -50,7 +50,7 @@ function SkeletonOverlay() {
   const theme = useTheme();
   return (
     <Box sx={{ width: "100%", pb: 1 }}>
-      {Array.from({ length: DEFAULT_LIMIT_VALUE }).map((_, i) => (
+      {Array.from({ length: getPersistedPageSize() }).map((_, i) => (
         <Box
           key={i}
           sx={{
@@ -319,7 +319,7 @@ export default function EntityTab({
               fontWeight: 700,
             },
             "& .MuiDataGrid-virtualScroller": {
-              ...(isLoading && { minHeight: `${DEFAULT_LIMIT_VALUE * 52}px !important` }),
+              ...(isLoading && { minHeight: `${getPersistedPageSize() * 52}px !important` }),
             },
             "& .MuiDataGrid-cell": {
               display: "flex",

--- a/apps/people-app/webapp/src/view/masterData/EntityTab.tsx
+++ b/apps/people-app/webapp/src/view/masterData/EntityTab.tsx
@@ -37,6 +37,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import { DataGrid, GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
 import { useCallback, useMemo, useState } from "react";
 import { DEFAULT_LIMIT_VALUE, PAGE_SIZE_OPTIONS } from "@config/constant";
+import { getPersistedPageSize, persistPageSize } from "@utils/utils";
 import {
   CreateEntityPayload,
   CompanyOrgChartEntity,
@@ -286,8 +287,9 @@ export default function EntityTab({
           loading={isLoading}
           localeText={{ noRowsLabel: `No ${entityLabel.toLowerCase()}s` }}
           initialState={{
-            pagination: { paginationModel: { pageSize: DEFAULT_LIMIT_VALUE } },
+            pagination: { paginationModel: { pageSize: getPersistedPageSize() } },
           }}
+          onPaginationModelChange={(model) => persistPageSize(model.pageSize)}
           pageSizeOptions={PAGE_SIZE_OPTIONS}
           slots={{ loadingOverlay: SkeletonOverlay }}
           disableRowSelectionOnClick


### PR DESCRIPTION
## Purpose

Follow-up improvements after #295, plus a production bug fix.

## Changes

### Bug fix — GET /offices failed with `Unknown column 'working_locations'`
The `working_locations` JSON column was dropped from the `office` table, but `getOfficesQuery` still selected it, so the offices endpoint always errored. Removed the column from the query, the `Office` record, the webapp `Office` mapping, and the creation script (`people_app_creation.sql`). Also picks up patch-level `Dependencies.toml` bumps from a rebuild with Ballerina 2201.12.7.

### Employees view — active-filter chips and counting
- Extracted the styled multi-select filter chip into a reusable `RemovableFilterChip` component with a `dropFilterValue` helper.
- The baseline filter state (Active + Marked leaver, exclude future joiners) is no longer counted as an active filter, so the filter badge and "Clear all" only appear when the user has actually narrowed the search.

### Rows-per-page persistence
The rows-per-page value a user picks is stored in `localStorage` under one shared key (`people-app-rows-per-page`) and restored on mount, so it survives navigation/reloads and applies uniformly to the employees, my-team, and master-data tables. Values outside `PAGE_SIZE_OPTIONS` fall back to the default.

### Webapp auth header
The webapp now duplicates the ID token into the `x-jwt-assertion` header read by the backend `JwtInterceptor`, allowing the webapp to call the backend directly when no gateway injects the header.

## Verification
- `bal build` — backend compiles clean.
- `npx tsc --noEmit` and eslint over all touched webapp files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Data tables now remember your preferred rows-per-page setting between sessions.
  - Added reusable removable filter chips for employee search filters.
- **Improvements**
  - Refined active-filter indicators to avoid counting default employee status filters.
  - Simplified office information by removing working-location details.
- **Bug Fixes**
  - Improved authenticated API requests by including the required identity assertion.
  - Updated supporting package versions for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->