### PR TITLE
[People App] Fix offices fetch failing on dropped working_locations column

### DIFF
--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1220,8 +1220,7 @@ isolated function getOfficesQuery(int? companyId = ()) returns sql:Parameterized
         SELECT 
             id,
             name,
-            location,
-            working_locations
+            location
         FROM office`;
     if companyId is int {
         query = sql:queryConcat(query, ` WHERE company_id = ${companyId}`);

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -608,9 +608,6 @@ public type Office record {|
     string name;
     # Office location
     string location;
-    # Working locations
-    @sql:Column {name: "working_locations"}
-    json workingLocations;
 |};
 
 # Employment type.


### PR DESCRIPTION
## Purpose

`GET /offices` fails with:

> Error while executing SQL query: SELECT id, name, location, working_locations FROM office;. Unknown column 'working_locations' in 'field list'.

The `working_locations` JSON column was dropped from the `office` table, but the backend still selects it.

## Changes

- `getOfficesQuery` no longer selects `working_locations`.
- Removed the `workingLocations` field from the backend `Office` record (the DB mapper requires every record field to be present in the result set).

No webapp changes needed: the `fetchOffices` mapping already falls back to `[]` when the field is absent.

## Verification

- `bal build` — backend compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)