### PR TITLE
[People App] Prevent duplicate car park bookings and double charges

### DIFF
--- a/apps/people-app/backend/modules/database/constants.bal
+++ b/apps/people-app/backend/modules/database/constants.bal
@@ -39,3 +39,6 @@ public const CONSULTANCY_ID_PREFIX = "CON";
 public const BULK_INSERT_SUCCESS = 1000;
 public const BULK_INSERT_DUPLICATE = 1001;
 public const BULK_INSERT_FAILED = 1002;
+
+# MySQL error code for a duplicate entry on a unique index/key.
+const MYSQL_DUPLICATE_ENTRY_ERROR_CODE = 1062;

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -984,6 +984,20 @@ public isolated function expireStalePendingParkingReservationsForEmployeeDate(st
     return result.affectedRowCount > 0;
 }
 
+# Update the vehicle on a parking reservation.
+#
+# + reservationId - Reservation id
+# + vehicleId - Registered vehicle id to set
+# + updatedBy - User performing the update
+# + return - True if updated, or error
+public isolated function updateParkingReservationVehicle(int reservationId, int vehicleId, string updatedBy)
+        returns boolean|error {
+
+    sql:ExecutionResult result = check databaseClient->execute(
+        updateParkingReservationVehicleQuery(reservationId, vehicleId, updatedBy));
+    return result.affectedRowCount > 0;
+}
+
 # Create parking reservation (PENDING).
 #
 # + payload - Reservation payload

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -956,12 +956,48 @@ public isolated function expireStalePendingParkingReservationForSlotDate(string 
     return result.affectedRowCount > 0;
 }
 
+# Get the caller's active reservation (CONFIRMED, or PENDING within `pendingExpiryMinutes`) for a date.
+#
+# + employeeEmail - Employee email
+# + bookingDate - Booking date (YYYY-MM-DD)
+# + pendingExpiryMinutes - Pending expiry duration in minutes
+# + return - Active reservation summary, nil if none, or error
+public isolated function getActiveParkingReservationForEmployeeDate(string employeeEmail, string bookingDate,
+        int pendingExpiryMinutes) returns ActiveParkingReservationRow|error? {
+
+    ActiveParkingReservationRow|error row = databaseClient->queryRow(
+        getActiveParkingReservationForEmployeeDateQuery(employeeEmail, bookingDate, pendingExpiryMinutes));
+    return row is sql:NoRowsError ? () : row;
+}
+
+# Expire the caller's stale PENDING reservations (PENDING -> EXPIRED) for a date (any slot).
+#
+# + employeeEmail - Employee email
+# + bookingDate - Booking date (YYYY-MM-DD)
+# + expiryMinutes - Expiry duration in minutes
+# + return - True if any rows updated, or error
+public isolated function expireStalePendingParkingReservationsForEmployeeDate(string employeeEmail,
+        string bookingDate, int expiryMinutes) returns boolean|error {
+
+    sql:ExecutionResult result = check databaseClient->execute(
+        expireStalePendingParkingReservationsForEmployeeDateQuery(employeeEmail, bookingDate, expiryMinutes));
+    return result.affectedRowCount > 0;
+}
+
 # Create parking reservation (PENDING).
 #
 # + payload - Reservation payload
-# + return - New reservation id
+# + return - New reservation id, `DuplicateActiveReservationError` if an active reservation already
+#            exists for the slot/date or employee/date (unique index violation), or error
 public isolated function addParkingReservation(AddParkingReservationPayload payload) returns int|error {
-    sql:ExecutionResult result = check databaseClient->execute(addParkingReservationQuery(payload));
+    sql:ExecutionResult|error result = databaseClient->execute(addParkingReservationQuery(payload));
+    if result is sql:DatabaseError && result.detail().errorCode == MYSQL_DUPLICATE_ENTRY_ERROR_CODE {
+        return error DuplicateActiveReservationError(
+            "An active reservation already exists for this slot or employee on this date.");
+    }
+    if result is error {
+        return result;
+    }
     return result.lastInsertId.ensureType(int);
 }
 

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2134,6 +2134,44 @@ isolated function expireStalePendingParkingReservationForSlotDateQuery(string sl
       AND status = ${PENDING}
       AND created_on < DATE_SUB(NOW(), INTERVAL ${expiryMinutes} MINUTE)`;
 
+# Get the caller's active reservation for a date (existence + reuse check).
+#
+# + employeeEmail - Employee email
+# + bookingDate - Booking date (YYYY-MM-DD)
+# + pendingExpiryMinutes - Pending expiry duration in minutes
+# + return - Query to get the employee's active reservation for the date
+isolated function getActiveParkingReservationForEmployeeDateQuery(string employeeEmail, string bookingDate,
+        int pendingExpiryMinutes) returns sql:ParameterizedQuery =>
+    `SELECT
+        id,
+        slot_id as 'slotId',
+        status,
+        coins_amount as 'coinsAmount'
+    FROM parking_reservation
+    WHERE employee_email = ${employeeEmail}
+      AND booking_date = ${bookingDate}
+      AND (
+        status = ${CONFIRMED}
+        OR (status = ${PENDING}
+            AND created_on >= DATE_SUB(NOW(), INTERVAL ${pendingExpiryMinutes} MINUTE))
+      )
+    LIMIT 1`;
+
+# Expire the caller's stale pending reservations (PENDING -> EXPIRED) for a date (any slot).
+#
+# + employeeEmail - Employee email
+# + bookingDate - Booking date (YYYY-MM-DD)
+# + expiryMinutes - Expiry duration in minutes
+# + return - Query to mark the employee's stale pending reservations as EXPIRED
+isolated function expireStalePendingParkingReservationsForEmployeeDateQuery(string employeeEmail, string bookingDate,
+        int expiryMinutes) returns sql:ParameterizedQuery =>
+    `UPDATE parking_reservation
+    SET status = ${EXPIRED}
+    WHERE employee_email = ${employeeEmail}
+      AND booking_date = ${bookingDate}
+      AND status = ${PENDING}
+      AND created_on < DATE_SUB(NOW(), INTERVAL ${expiryMinutes} MINUTE)`;
+
 # Insert parking reservation (PENDING).
 #
 # + payload - Reservation payload

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2145,6 +2145,7 @@ isolated function getActiveParkingReservationForEmployeeDateQuery(string employe
     `SELECT
         id,
         slot_id as 'slotId',
+        vehicle_id as 'vehicleId',
         status,
         coins_amount as 'coinsAmount'
     FROM parking_reservation
@@ -2171,6 +2172,18 @@ isolated function expireStalePendingParkingReservationsForEmployeeDateQuery(stri
       AND booking_date = ${bookingDate}
       AND status = ${PENDING}
       AND created_on < DATE_SUB(NOW(), INTERVAL ${expiryMinutes} MINUTE)`;
+
+# Update the vehicle on a parking reservation.
+#
+# + reservationId - Reservation id
+# + vehicleId - Registered vehicle id to set
+# + updatedBy - User performing the update
+# + return - Query to update the reservation's vehicle
+isolated function updateParkingReservationVehicleQuery(int reservationId, int vehicleId, string updatedBy)
+        returns sql:ParameterizedQuery =>
+    `UPDATE parking_reservation
+    SET vehicle_id = ${vehicleId}, updated_by = ${updatedBy}
+    WHERE id = ${reservationId}`;
 
 # Insert parking reservation (PENDING).
 #

--- a/apps/people-app/backend/modules/database/enums.bal
+++ b/apps/people-app/backend/modules/database/enums.bal
@@ -31,8 +31,6 @@ public enum ParkingReservationStatus {
     PENDING,
     CONFIRMED,
     EXPIRED,
-    // Historical duplicate collapsed during the v1.0.21 migration so the
-    // per-employee/date unique index could be created; retained for audit.
     DUPLICATE
 }
 

--- a/apps/people-app/backend/modules/database/enums.bal
+++ b/apps/people-app/backend/modules/database/enums.bal
@@ -30,7 +30,10 @@ public enum VehicleStatus {
 public enum ParkingReservationStatus {
     PENDING,
     CONFIRMED,
-    EXPIRED
+    EXPIRED,
+    // Historical duplicate collapsed during the v1.0.21 migration so the
+    // per-employee/date unique index could be created; retained for audit.
+    DUPLICATE
 }
 
 # [Database] Enum for employee statuses.

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -41,6 +41,10 @@ public type EntityNotFoundError distinct error;
 # Distinct error returned when a PATCH payload carries no fields to update.
 public type NoFieldsToUpdateError distinct error;
 
+# Distinct error returned when a parking reservation insert violates an
+# active-reservation unique index (slot/date or employee/date already active).
+public type DuplicateActiveReservationError distinct error;
+
 # [Configurable] Database configs.
 type DatabaseConfig record {|
     # If the MySQL server is secured, the username
@@ -1210,6 +1214,18 @@ public type ParkingReservationDetails record {|
 public type ReservationIdRow record {|
     # Reservation identifier
     int id;
+|};
+
+# [Database] Active reservation summary for an employee/date lookup.
+public type ActiveParkingReservationRow record {|
+    # Reservation identifier
+    int id;
+    # Slot identifier
+    string slotId;
+    # Reservation status
+    ParkingReservationStatus status;
+    # Amount to be paid in coins
+    decimal coinsAmount;
 |};
 
 # Payload to create a company org chart entity (business unit, team, sub-team, or unit).

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -1222,6 +1222,8 @@ public type ActiveParkingReservationRow record {|
     int id;
     # Slot identifier
     string slotId;
+    # Registered vehicle ID on the reservation
+    int vehicleId;
     # Reservation status
     ParkingReservationStatus status;
     # Amount to be paid in coins

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -467,7 +467,7 @@ CREATE TABLE `parking_reservation` (
   `booking_date` date NOT NULL,
   `employee_email` varchar(100) NOT NULL,
   `vehicle_id` int NOT NULL,
-  `status` enum('PENDING','CONFIRMED','EXPIRED') NOT NULL DEFAULT 'PENDING',
+  `status` enum('PENDING','CONFIRMED','EXPIRED','DUPLICATE') NOT NULL DEFAULT 'PENDING',
   `transaction_hash` varchar(255) DEFAULT NULL,
   `coins_amount` decimal(10, 4) NOT NULL,
   `created_on` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -489,6 +489,14 @@ CREATE UNIQUE INDEX `uk_active_slot_booking_date` ON `parking_reservation` ((
   END
 ));
 
+-- Functional UNIQUE index: one active (PENDING/CONFIRMED) reservation per employee per date.
+CREATE UNIQUE INDEX `uk_active_employee_booking_date` ON `parking_reservation` ((
+  CASE
+    WHEN `status` IN ('PENDING', 'CONFIRMED') THEN CONCAT(`employee_email`, '|', `booking_date`)
+    ELSE NULL
+  END
+));
+
 -- Personal Info Audit table
 CREATE TABLE `personal_info_audit` (
   `id` bigint NOT NULL AUTO_INCREMENT,

--- a/apps/people-app/backend/resources/people_app_table_update_v1.0.21.sql
+++ b/apps/people-app/backend/resources/people_app_table_update_v1.0.21.sql
@@ -9,20 +9,27 @@
 -- paid reservation and charged the wallet twice.
 --
 -- This functional unique index mirrors uk_active_slot_booking_date but is keyed
--- on the employee instead of the slot. EXPIRED rows map to NULL so they are
--- ignored by the index, allowing a fresh booking once a prior attempt expires.
+-- on the employee instead of the slot. Non-active rows (EXPIRED, DUPLICATE) map
+-- to NULL so they are ignored by the index, allowing a fresh booking once a
+-- prior attempt is no longer active.
 --
 -- Pre-cleanup: because this bug allowed multiple active reservations per
 -- employee/date, production may already hold such duplicates (the reported
 -- incident is one). CREATE UNIQUE INDEX would fail (error 1062) on them, so
--- first expire all-but-one active row per (employee_email, booking_date),
--- keeping the CONFIRMED row when present, otherwise the most recent id. The
--- derived table is materialized, so updating parking_reservation while reading
--- it in the subquery does not hit MySQL error 1093.
+-- first collapse all-but-one active row per (employee_email, booking_date) to a
+-- new DUPLICATE status, keeping the CONFIRMED row when present, otherwise the
+-- most recent id. DUPLICATE (rather than EXPIRED) preserves the fact that these
+-- were genuine, often paid, bookings for audit/refund purposes. The derived
+-- table is materialized, so updating parking_reservation while reading it in the
+-- subquery does not hit MySQL error 1093.
 -- =====================================================================
 
+-- Add the DUPLICATE status before it is assigned below.
+ALTER TABLE `parking_reservation`
+    MODIFY COLUMN `status` ENUM ('PENDING', 'CONFIRMED', 'EXPIRED', 'DUPLICATE') NOT NULL DEFAULT 'PENDING';
+
 UPDATE `parking_reservation`
-SET `status` = 'EXPIRED'
+SET `status` = 'DUPLICATE'
 WHERE `status` IN ('PENDING', 'CONFIRMED')
   AND `id` NOT IN (
     SELECT `keep_id` FROM (

--- a/apps/people-app/backend/resources/people_app_table_update_v1.0.21.sql
+++ b/apps/people-app/backend/resources/people_app_table_update_v1.0.21.sql
@@ -11,7 +11,31 @@
 -- This functional unique index mirrors uk_active_slot_booking_date but is keyed
 -- on the employee instead of the slot. EXPIRED rows map to NULL so they are
 -- ignored by the index, allowing a fresh booking once a prior attempt expires.
+--
+-- Pre-cleanup: because this bug allowed multiple active reservations per
+-- employee/date, production may already hold such duplicates (the reported
+-- incident is one). CREATE UNIQUE INDEX would fail (error 1062) on them, so
+-- first expire all-but-one active row per (employee_email, booking_date),
+-- keeping the CONFIRMED row when present, otherwise the most recent id. The
+-- derived table is materialized, so updating parking_reservation while reading
+-- it in the subquery does not hit MySQL error 1093.
 -- =====================================================================
+
+UPDATE `parking_reservation`
+SET `status` = 'EXPIRED'
+WHERE `status` IN ('PENDING', 'CONFIRMED')
+  AND `id` NOT IN (
+    SELECT `keep_id` FROM (
+        SELECT `id` AS `keep_id`,
+               ROW_NUMBER() OVER (
+                   PARTITION BY `employee_email`, `booking_date`
+                   ORDER BY (`status` = 'CONFIRMED') DESC, `id` DESC
+               ) AS `rn`
+        FROM `parking_reservation`
+        WHERE `status` IN ('PENDING', 'CONFIRMED')
+    ) `ranked`
+    WHERE `rn` = 1
+  );
 
 CREATE UNIQUE INDEX `uk_active_employee_booking_date` ON `parking_reservation` ((
     CASE

--- a/apps/people-app/backend/resources/people_app_table_update_v1.0.21.sql
+++ b/apps/people-app/backend/resources/people_app_table_update_v1.0.21.sql
@@ -1,0 +1,22 @@
+-- =====================================================================
+-- people_app_table_update_v1.0.21.sql
+-- Fix: prevent a single employee from holding more than one active
+--      (PENDING or CONFIRMED) parking reservation per booking date.
+--
+-- Until now uniqueness was enforced per slot only (uk_active_slot_booking_date,
+-- v1.0.11). Nothing stopped one employee from booking multiple slots on the
+-- same day, so a retry after a spurious "booking failed" error created a second
+-- paid reservation and charged the wallet twice.
+--
+-- This functional unique index mirrors uk_active_slot_booking_date but is keyed
+-- on the employee instead of the slot. EXPIRED rows map to NULL so they are
+-- ignored by the index, allowing a fresh booking once a prior attempt expires.
+-- =====================================================================
+
+CREATE UNIQUE INDEX `uk_active_employee_booking_date` ON `parking_reservation` ((
+    CASE
+        WHEN status IN ('PENDING', 'CONFIRMED')
+            THEN CONCAT(employee_email, '|', booking_date)
+        ELSE NULL
+    END
+));

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -1872,6 +1872,17 @@ service http:InterceptableService / on new http:Listener(9090) {
         if activeReservation is database:ActiveParkingReservationRow {
             // Same-slot PENDING: reuse it so a retry does not create (or pay for) a second booking.
             if activeReservation.status == database:PENDING && activeReservation.slotId == body.slotId {
+                // Keep the reused reservation aligned with the vehicle chosen on this attempt.
+                if activeReservation.vehicleId != body.vehicleId {
+                    boolean|error vehicleUpdated = database:updateParkingReservationVehicle(
+                        activeReservation.id, body.vehicleId, userInfo.email);
+                    if vehicleUpdated is error {
+                        log:printError("Error updating vehicle on reused reservation", vehicleUpdated);
+                        return <http:InternalServerError>{
+                            body: {message: "Error occurred while updating reservation."}
+                        };
+                    }
+                }
                 return {
                     reservationId: activeReservation.id,
                     coinsAmount: activeReservation.coinsAmount

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -1848,6 +1848,48 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
+        // Expire the caller's own stale pending reservations for the date (any slot), so an
+        // abandoned attempt does not block a fresh booking.
+        boolean|error clearedForEmployee = database:expireStalePendingParkingReservationsForEmployeeDate(
+            userInfo.email, body.bookingDate, wso2_coin:pendingReservationExpiryMinutes);
+        if clearedForEmployee is error {
+            log:printError("Error expiring stale pending reservations for employee", clearedForEmployee);
+            return <http:InternalServerError>{
+                body: {message: "Error occurred while validating booking eligibility."}
+            };
+        }
+
+        // Enforce one active (PENDING/CONFIRMED) reservation per employee per day.
+        database:ActiveParkingReservationRow|error? activeReservation =
+            database:getActiveParkingReservationForEmployeeDate(userInfo.email, body.bookingDate,
+                wso2_coin:pendingReservationExpiryMinutes);
+        if activeReservation is error {
+            log:printError("Error checking existing reservations for employee", activeReservation);
+            return <http:InternalServerError>{
+                body: {message: "Error occurred while validating booking eligibility."}
+            };
+        }
+        if activeReservation is database:ActiveParkingReservationRow {
+            // Same-slot PENDING: reuse it so a retry does not create (or pay for) a second booking.
+            if activeReservation.status == database:PENDING && activeReservation.slotId == body.slotId {
+                return {
+                    reservationId: activeReservation.id,
+                    coinsAmount: activeReservation.coinsAmount
+                };
+            }
+            log:printWarn("Employee already has an active parking reservation for the date",
+                    invokerEmail = userInfo.email, bookingDate = body.bookingDate,
+                    existingSlot = activeReservation.slotId);
+            string activeMsg = activeReservation.status == database:CONFIRMED
+                ? string `You already have a confirmed parking booking for ${body.bookingDate}`
+                    + string ` (slot ${activeReservation.slotId}).`
+                : string `You already have a pending parking booking for ${body.bookingDate}`
+                    + string ` (slot ${activeReservation.slotId}). Complete or cancel it before booking another.`;
+            return <http:BadRequest>{
+                body: {message: activeMsg}
+            };
+        }
+
         // Expire stale pending reservations so the slot/date becomes reusable.
         boolean|error cleared = database:expireStalePendingParkingReservationForSlotDate(body.slotId, body.bookingDate,
             wso2_coin:pendingReservationExpiryMinutes);
@@ -1884,6 +1926,16 @@ service http:InterceptableService / on new http:Listener(9090) {
             coinsAmount: slot.coinsPerSlot,
             createdBy: userInfo.email
         });
+        if reservationId is database:DuplicateActiveReservationError {
+            log:printWarn("Duplicate active parking reservation blocked by unique index",
+                    invokerEmail = userInfo.email, bookingDate = body.bookingDate, slotId = body.slotId);
+            return <http:BadRequest>{
+                body: {
+                    message: "You already have an active booking for this date, or the slot was just taken. "
+                        + "Please refresh and try again."
+                }
+            };
+        }
         if reservationId is error {
             log:printError("Error creating parking reservation", reservationId);
             return <http:InternalServerError>{

--- a/apps/people-app/microapp/src/pages/ParkingBookingSummaryPage.tsx
+++ b/apps/people-app/microapp/src/pages/ParkingBookingSummaryPage.tsx
@@ -262,37 +262,43 @@ function ParkingBookingSummaryPage() {
           reservationId,
         );
 
-        // Already confirmed (e.g. a prior attempt succeeded but surfaced a
-        // spurious error): finish without charging again.
         if (existing.status === "CONFIRMED") {
+          // A prior attempt succeeded but surfaced a spurious error: finish
+          // without charging again.
           await finalizeParkingConfirmationAfterSuccess(existing, navigate);
           return;
-        }
-
-        // A prior wallet payment succeeded but was never confirmed: confirm with
-        // that transaction hash instead of opening the wallet (and paying) again.
-        const priorStatus = await getLocalDataAsync(
-          PARKING_WALLET_PAYMENT_STATUS_KEY,
-        );
-        if (String(priorStatus) === "SUCCESS") {
-          const priorTxRaw = await getLocalDataAsync(
-            PARKING_WALLET_PAYMENT_TX_HASH_KEY,
+        } else if (existing.status === "PENDING") {
+          // A prior wallet payment succeeded but was never confirmed: confirm
+          // with that transaction hash instead of paying again.
+          const priorStatus = await getLocalDataAsync(
+            PARKING_WALLET_PAYMENT_STATUS_KEY,
           );
-          const priorTx = priorTxRaw ? String(priorTxRaw).trim() : "";
-          if (priorTx) {
-            const confirmed = await confirmParkingReservation(
-              handleRequest,
-              handleRequestWithNewToken,
-              reservationId,
-              priorTx,
+          if (String(priorStatus) === "SUCCESS") {
+            const priorTxRaw = await getLocalDataAsync(
+              PARKING_WALLET_PAYMENT_TX_HASH_KEY,
             );
-            await finalizeParkingConfirmationAfterSuccess(confirmed, navigate);
-            return;
+            const priorTx = priorTxRaw ? String(priorTxRaw).trim() : "";
+            if (priorTx) {
+              const confirmed = await confirmParkingReservation(
+                handleRequest,
+                handleRequestWithNewToken,
+                reservationId,
+                priorTx,
+              );
+              await finalizeParkingConfirmationAfterSuccess(confirmed, navigate);
+              return;
+            }
           }
+          coinsAmount = existing.coinsAmount;
+        } else {
+          // Stale reservation (e.g. EXPIRED after the pending window lapsed).
+          // Reusing it would charge the wallet again only for the confirm to be
+          // rejected server-side, so discard it and create a fresh one below.
+          reservationId = undefined;
         }
+      }
 
-        coinsAmount = existing.coinsAmount;
-      } else {
+      if (!reservationId) {
         // Stage 1: create a pending reservation in backend. The backend enforces
         // one active booking per employee/day and is idempotent for a same-slot
         // retry, so this cannot silently create a duplicate.

--- a/apps/people-app/microapp/src/pages/ParkingBookingSummaryPage.tsx
+++ b/apps/people-app/microapp/src/pages/ParkingBookingSummaryPage.tsx
@@ -47,6 +47,7 @@ import {
   PARKING_WALLET_PAYMENT_TX_HASH_KEY,
   clearWalletParkingPaymentBridgeKeys,
   confirmParkingReservation,
+  fetchParkingReservationById,
   finalizeParkingConfirmationAfterSuccess,
 } from "@/utils/parkingConfirm";
 import { Logger } from "@/utils/logger";
@@ -228,7 +229,7 @@ function ParkingBookingSummaryPage() {
             error: error ? String(error) : undefined,
           };
         }
-      } catch (e) {
+      } catch {
         // Ignore polling errors; keep waiting.
       }
 
@@ -246,15 +247,65 @@ function ParkingBookingSummaryPage() {
     setError(undefined);
     setShowPaymentFailureModal(false);
 
-    try {
-      // Stage 1: create a pending reservation in backend.
-      const reservation = await createReservation();
+    let reservationId = paymentContext.reservationId;
+    let coinsAmount = paymentContext.coinsAmount;
 
-      setParkingPaymentContextState({
-        ...paymentContext,
-        reservationId: reservation.reservationId,
-        coinsAmount: reservation.coinsAmount,
-      });
+    try {
+      // Recovery path: if a reservation was already created on a previous attempt,
+      // never create a second one or open the wallet again — that would charge the
+      // user twice. Reuse it, and settle it without re-charging when it is already
+      // paid or confirmed.
+      if (reservationId) {
+        const existing = await fetchParkingReservationById(
+          handleRequest,
+          handleRequestWithNewToken,
+          reservationId,
+        );
+
+        // Already confirmed (e.g. a prior attempt succeeded but surfaced a
+        // spurious error): finish without charging again.
+        if (existing.status === "CONFIRMED") {
+          await finalizeParkingConfirmationAfterSuccess(existing, navigate);
+          return;
+        }
+
+        // A prior wallet payment succeeded but was never confirmed: confirm with
+        // that transaction hash instead of opening the wallet (and paying) again.
+        const priorStatus = await getLocalDataAsync(
+          PARKING_WALLET_PAYMENT_STATUS_KEY,
+        );
+        if (String(priorStatus) === "SUCCESS") {
+          const priorTxRaw = await getLocalDataAsync(
+            PARKING_WALLET_PAYMENT_TX_HASH_KEY,
+          );
+          const priorTx = priorTxRaw ? String(priorTxRaw).trim() : "";
+          if (priorTx) {
+            const confirmed = await confirmParkingReservation(
+              handleRequest,
+              handleRequestWithNewToken,
+              reservationId,
+              priorTx,
+            );
+            await finalizeParkingConfirmationAfterSuccess(confirmed, navigate);
+            return;
+          }
+        }
+
+        coinsAmount = existing.coinsAmount;
+      } else {
+        // Stage 1: create a pending reservation in backend. The backend enforces
+        // one active booking per employee/day and is idempotent for a same-slot
+        // retry, so this cannot silently create a duplicate.
+        const reservation = await createReservation();
+        reservationId = reservation.reservationId;
+        coinsAmount = reservation.coinsAmount;
+
+        setParkingPaymentContextState({
+          ...paymentContext,
+          reservationId,
+          coinsAmount,
+        });
+      }
 
       // Stage 2: ask Wallet to transfer coins, then confirm reservation with txHash.
       const carParkConfig = await new Promise<CarParkConfigResponse>(
@@ -279,7 +330,7 @@ function ParkingBookingSummaryPage() {
       requestOpenMicroApp("com.wso2.superapp.microapp.wallet", {
         initialRoute: "/send",
         wallet_address: carParkConfig.publicWalletAddress,
-        coin_amount: reservation.coinsAmount,
+        coin_amount: coinsAmount,
         source_app_id: "com.wso2.superapp.microapp.people",
         return_app_id: "com.wso2.superapp.microapp.people",
         return_route: "/services/parking/summary",
@@ -297,12 +348,34 @@ function ParkingBookingSummaryPage() {
       const confirmed = await confirmParkingReservation(
         handleRequest,
         handleRequestWithNewToken,
-        reservation.reservationId,
+        reservationId,
         paymentResult.txHash,
       );
 
       await finalizeParkingConfirmationAfterSuccess(confirmed, navigate);
     } catch (e) {
+      // A concurrent confirmation (ParkingWalletReturnResume) may have already
+      // succeeded, or our confirm response was lost mid-flight. Verify server
+      // state before declaring failure so a booking that actually went through
+      // never shows a false "payment failed" error (which drove the duplicate
+      // re-submissions this flow was fixed for).
+      const rid = getParkingPaymentContextState()?.reservationId ?? reservationId;
+      if (rid) {
+        try {
+          const existing = await fetchParkingReservationById(
+            handleRequest,
+            handleRequestWithNewToken,
+            rid,
+          );
+          if (existing.status === "CONFIRMED") {
+            await finalizeParkingConfirmationAfterSuccess(existing, navigate);
+            return;
+          }
+        } catch (verifyErr) {
+          Logger.error("Parking confirm recovery check failed", verifyErr);
+        }
+      }
+
       const msg = String(e ?? "Payment failed");
       setError(msg);
       setShowPaymentFailureModal(true);

--- a/apps/people-app/microapp/src/pages/ParkingSlotSelectionPage.tsx
+++ b/apps/people-app/microapp/src/pages/ParkingSlotSelectionPage.tsx
@@ -28,6 +28,7 @@ import { PageTransitionWrapper, BottomNav } from "@/components/shared";
 import type {
   CarParkConfigResponse,
   ParkingFloor,
+  ParkingReservationDetails,
   ParkingSlot,
   VehicleResponse,
 } from "@/types";
@@ -65,6 +66,12 @@ function ParkingSlotSelectionPage() {
   const [error, setError] = useState<string | undefined>(undefined);
   const [vehiclesLoading, setVehiclesLoading] = useState(true);
   const [vehiclesSetupRequired, setVehiclesSetupRequired] = useState(false);
+
+  // Only one parking booking is allowed per employee per day. Holds the caller's
+  // existing active (PENDING/CONFIRMED) reservation for today, if any.
+  const [existingBooking, setExistingBooking] =
+    useState<ParkingReservationDetails | null>(null);
+  const [checkingExistingBooking, setCheckingExistingBooking] = useState(true);
 
   const [reservationWindowStartHour, setReservationWindowStartHour] =
     useState(5);
@@ -232,13 +239,49 @@ function ParkingSlotSelectionPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFloorId]);
 
+  // Check upfront whether the caller already has a booking for today, so the
+  // Proceed to Payment button can be disabled instead of failing at payment.
+  useEffect(() => {
+    let cancelled = false;
+    setCheckingExistingBooking(true);
+    executeWithTokenHandling(
+      handleRequest,
+      handleRequestWithNewToken,
+      serviceUrls.fetchParkingReservations(todayBookingDate, todayBookingDate),
+      "GET",
+      null,
+      (data) => {
+        if (cancelled) return;
+        const list = (data as ParkingReservationDetails[]) ?? [];
+        const active = list.find(
+          (r) => r.status === "PENDING" || r.status === "CONFIRMED",
+        );
+        setExistingBooking(active ?? null);
+        setCheckingExistingBooking(false);
+      },
+      () => {
+        // On failure don't block booking; the backend still guards duplicates.
+        if (cancelled) return;
+        setExistingBooking(null);
+        setCheckingExistingBooking(false);
+      },
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleProceedToPayment = () => {
     if (
       !isBookingWindowActive ||
       !selectedSlot ||
       busyPayment ||
       vehiclesLoading ||
-      vehiclesSetupRequired
+      vehiclesSetupRequired ||
+      checkingExistingBooking ||
+      existingBooking
     ) {
       if (!vehiclesLoading && vehiclesSetupRequired) {
         navigate("/services/vehicles");
@@ -477,19 +520,37 @@ function ParkingSlotSelectionPage() {
                     busyPayment ||
                     selectedSlot.isBooked ||
                     vehiclesLoading ||
-                    vehiclesSetupRequired
+                    vehiclesSetupRequired ||
+                    checkingExistingBooking ||
+                    Boolean(existingBooking)
                   }
                   onClick={handleProceedToPayment}
                 >
                   {busyPayment
                     ? "Redirecting..."
-                    : vehiclesLoading
-                      ? "Checking vehicles..."
-                      : vehiclesSetupRequired
-                        ? "Add a vehicle to continue"
-                        : "Proceed to Payment"}
+                    : vehiclesLoading || checkingExistingBooking
+                      ? "Checking..."
+                      : existingBooking
+                        ? "You already have a booking today"
+                        : vehiclesSetupRequired
+                          ? "Add a vehicle to continue"
+                          : "Proceed to Payment"}
                 </button>
-                {vehiclesSetupRequired && !vehiclesLoading && (
+                {existingBooking && (
+                  <>
+                    <div className="mt-2 text-[12.5px] text-center text-[#808080] font-medium">
+                      Only one parking booking is allowed per day.
+                    </div>
+                    <button
+                      type="button"
+                      className="mt-3 w-full p-[0.75rem] text-[14px] font-semibold rounded-[0.7rem] border border-[#E5E5E5] bg-white text-[#1F2A44]"
+                      onClick={() => navigate("/services/parking/bookings")}
+                    >
+                      View My Bookings
+                    </button>
+                  </>
+                )}
+                {vehiclesSetupRequired && !vehiclesLoading && !existingBooking && (
                   <button
                     type="button"
                     className="mt-3 w-full p-[0.75rem] text-[14px] font-semibold rounded-[0.7rem] border border-[#E5E5E5] bg-white text-[#1F2A44]"

--- a/apps/people-app/microapp/src/pages/ParkingSlotSelectionPage.tsx
+++ b/apps/people-app/microapp/src/pages/ParkingSlotSelectionPage.tsx
@@ -271,7 +271,7 @@ function ParkingSlotSelectionPage() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [todayBookingDate]);
 
   const handleProceedToPayment = () => {
     if (
@@ -457,7 +457,25 @@ function ParkingSlotSelectionPage() {
         </section>
 
         <div className="fixed left-4 right-4 bottom-[calc(84px+var(--safe-bottom))]">
-          {reservationConfigLoaded && !isBookingWindowActive && (
+          {existingBooking && (
+            <div className="bg-white rounded-[1rem] shadow-[0_10px_30px_rgba(0,0,0,0.08)] border border-[#E5E5E5] p-4">
+              <div className="text-[15px] font-bold text-[#1F2A44]">
+                You already have a booking for today
+              </div>
+              <div className="mt-1 text-[13px] text-[#808080] font-medium leading-snug">
+                Only one parking booking is allowed per day.
+              </div>
+              <button
+                type="button"
+                className="mt-3 w-full p-[0.85rem] text-[15px] font-semibold rounded-[0.7rem] bg-primary text-white"
+                onClick={() => navigate("/services/parking/bookings")}
+              >
+                View My Bookings
+              </button>
+            </div>
+          )}
+
+          {!existingBooking && reservationConfigLoaded && !isBookingWindowActive && (
             <div className="bg-[#FFF7EB] rounded-[1rem] shadow-[0_8px_24px_rgba(0,0,0,0.08)] border border-[#FFB74D] px-4 py-3">
               <div className="flex items-start gap-3">
                 <div className="mt-0.5 shrink-0">
@@ -479,7 +497,7 @@ function ParkingSlotSelectionPage() {
             </div>
           )}
 
-          {isBookingWindowActive && selectedSlot && (
+          {!existingBooking && isBookingWindowActive && selectedSlot && (
             <div className="bg-white rounded-[1rem] shadow-[0_10px_30px_rgba(0,0,0,0.08)] border border-[#E5E5E5] p-4">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -521,8 +539,7 @@ function ParkingSlotSelectionPage() {
                     selectedSlot.isBooked ||
                     vehiclesLoading ||
                     vehiclesSetupRequired ||
-                    checkingExistingBooking ||
-                    Boolean(existingBooking)
+                    checkingExistingBooking
                   }
                   onClick={handleProceedToPayment}
                 >
@@ -530,27 +547,11 @@ function ParkingSlotSelectionPage() {
                     ? "Redirecting..."
                     : vehiclesLoading || checkingExistingBooking
                       ? "Checking..."
-                      : existingBooking
-                        ? "You already have a booking today"
-                        : vehiclesSetupRequired
-                          ? "Add a vehicle to continue"
-                          : "Proceed to Payment"}
+                      : vehiclesSetupRequired
+                        ? "Add a vehicle to continue"
+                        : "Proceed to Payment"}
                 </button>
-                {existingBooking && (
-                  <>
-                    <div className="mt-2 text-[12.5px] text-center text-[#808080] font-medium">
-                      Only one parking booking is allowed per day.
-                    </div>
-                    <button
-                      type="button"
-                      className="mt-3 w-full p-[0.75rem] text-[14px] font-semibold rounded-[0.7rem] border border-[#E5E5E5] bg-white text-[#1F2A44]"
-                      onClick={() => navigate("/services/parking/bookings")}
-                    >
-                      View My Bookings
-                    </button>
-                  </>
-                )}
-                {vehiclesSetupRequired && !vehiclesLoading && !existingBooking && (
+                {vehiclesSetupRequired && !vehiclesLoading && (
                   <button
                     type="button"
                     className="mt-3 w-full p-[0.75rem] text-[14px] font-semibold rounded-[0.7rem] border border-[#E5E5E5] bg-white text-[#1F2A44]"

--- a/apps/people-app/microapp/src/pages/ParkingSlotSelectionPage.tsx
+++ b/apps/people-app/microapp/src/pages/ParkingSlotSelectionPage.tsx
@@ -68,7 +68,9 @@ function ParkingSlotSelectionPage() {
   const [vehiclesSetupRequired, setVehiclesSetupRequired] = useState(false);
 
   // Only one parking booking is allowed per employee per day. Holds the caller's
-  // existing active (PENDING/CONFIRMED) reservation for today, if any.
+  // existing CONFIRMED reservation for today, if any. A PENDING booking is left to
+  // the backend, which reuses a same-slot pending and expires stale ones, so a
+  // stale abandoned pending never blocks re-booking here.
   const [existingBooking, setExistingBooking] =
     useState<ParkingReservationDetails | null>(null);
   const [checkingExistingBooking, setCheckingExistingBooking] = useState(true);
@@ -253,9 +255,7 @@ function ParkingSlotSelectionPage() {
       (data) => {
         if (cancelled) return;
         const list = (data as ParkingReservationDetails[]) ?? [];
-        const active = list.find(
-          (r) => r.status === "PENDING" || r.status === "CONFIRMED",
-        );
+        const active = list.find((r) => r.status === "CONFIRMED");
         setExistingBooking(active ?? null);
         setCheckingExistingBooking(false);
       },

--- a/apps/people-app/microapp/src/types/parking.ts
+++ b/apps/people-app/microapp/src/types/parking.ts
@@ -42,7 +42,11 @@ export interface CreateParkingReservationResponse {
   coinsAmount: DecimalLike;
 }
 
-export type ParkingReservationStatus = "PENDING" | "CONFIRMED" | "EXPIRED";
+export type ParkingReservationStatus =
+  | "PENDING"
+  | "CONFIRMED"
+  | "EXPIRED"
+  | "DUPLICATE";
 
 export interface ParkingReservationDetails {
   id: number;


### PR DESCRIPTION
## Problem

A user who hit a **"payment failed"** error in the Car Park Booking flow and re-submitted ended up with **two confirmed bookings, two on-chain transactions, and two Google Sheet rows** for the same day (charged 0.04 O2C twice for one physical slot). Reported by a user with a screenshot of two `CONFIRMED` bookings.

## Root cause

Two defects combined:

1. **Trigger — false "payment failed" error.** The wallet payment is confirmed by **two independent drivers sharing the same bridge keys**: the inline poll in `ParkingBookingSummaryPage.handleConfirmAndPay` and the globally-mounted `ParkingWalletReturnResume` (`App.tsx`). On return from the wallet they race — the winner confirms the reservation and clears the bridge keys, so the loser either times out (`"Payment timed out"`) or gets `"already CONFIRMED"` and shows **Payment Unsuccessful** on a booking that actually succeeded and was already charged. That false error is what made the user retry.
2. **Root cause — no per-user guard.** Uniqueness was enforced **per slot only** (`uk_active_slot_booking_date`), never per user. The retry landed on a **different slot**, so `createReservation` succeeded, the wallet transferred a **second** time, and a second booking was confirmed.

## Changes

**Backend — authoritative guarantee**
- New functional unique index `uk_active_employee_booking_date`: at most one `PENDING`/`CONFIRMED` reservation per employee per booking date (migration `v1.0.21` + `people_app_creation.sql`), mirroring the existing slot index (EXPIRED excluded).
- New DB layer: `getActiveParkingReservationForEmployeeDate`, `expireStalePendingParkingReservationsForEmployeeDate`, `ActiveParkingReservationRow`, and a `DuplicateActiveReservationError` distinct error; `addParkingReservation` maps MySQL `1062` to it (structured, mirroring `utils.bal:getErrorCode`).
- `POST /parkings/reservations`: expires the caller's stale pendings, **reuses** a same-slot `PENDING` (idempotent retry — no second charge), returns **400** if the caller already holds a booking for the date, and maps the unique-index race to a clean 400. A retry on a new slot now fails **before** the wallet opens.

**Frontend — kills the false error and re-charge (`ParkingBookingSummaryPage.handleConfirmAndPay`)**
- Reuses an existing `reservationId` instead of blindly re-creating; before charging, finishes without paying again when the reservation is already `CONFIRMED` or a prior wallet payment succeeded but wasn't confirmed.
- The `catch` now **verifies server state before showing failure**, so a booking that actually went through no longer surfaces a spurious error.

## Verification

- **Microapp:** `tsc -b`, `eslint`, and `vite build` all pass.
- **Backend:** could **not** be compiled locally — the installed `bal` is `2201.7.5`, which crashes (`NoSuchElementException` in `RegExpParser.parseInterpolation`) on the pre-existing `re \`\${EMAIL_PATTERN}\`` in `types.bal` while scanning imports; this reproduces on a pristine `main`, so it is an environment issue (project targets `2201.12.7`), not this change. Please confirm via CI. The Ballerina edits follow existing patterns exactly.

## Not in scope
- The 0.04 O2C refund to the affected user is a manual wallet ops action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Employees can now have only one active parking reservation per day (pending/confirmed).
  * Repeating a request can reuse your existing pending reservation when it matches the same day and slot.
  * Stale pending reservations are automatically expired before new bookings.
  * Slot selection now shows an “already booked today” notice with “View My Bookings” and disables starting another booking while checking.

* **Bug Fixes**
  * Improved confirm-and-pay recovery to prevent duplicate charges and finalize confirmation safely after interruptions.
  * Clearer handling when an active reservation conflict occurs (refresh and retry).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->