### PR TITLE
[People App] Fix duplicate employee entries returned to UI

### DIFF
--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -386,10 +386,12 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
 # + return - Parameterized query for fetching distinct managers
 isolated function getManagersQuery() returns sql:ParameterizedQuery =>
     `SELECT
-        SUBSTRING_INDEX(GROUP_CONCAT(m.employee_id ORDER BY m.id DESC SEPARATOR '||'), '||', 1) AS employee_id,
+        SUBSTRING_INDEX(
+            GROUP_CONCAT(m.employee_id ORDER BY (m.employee_status = 'Active') DESC, m.id DESC SEPARATOR '||'), '||', 1
+        ) AS employee_id,
         m.work_email
     FROM employee e
-    JOIN employee m ON e.manager_email = m.work_email
+    JOIN employee m ON LOWER(e.manager_email) = LOWER(m.work_email)
     WHERE e.manager_email IS NOT NULL AND e.manager_email <> ''
     GROUP BY m.work_email;`;
 

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -389,11 +389,13 @@ isolated function getManagersQuery() returns sql:ParameterizedQuery =>
         SUBSTRING_INDEX(
             GROUP_CONCAT(m.employee_id ORDER BY (m.employee_status = 'Active') DESC, m.id DESC SEPARATOR '||'), '||', 1
         ) AS employee_id,
-        m.work_email
+        SUBSTRING_INDEX(
+            GROUP_CONCAT(m.work_email ORDER BY (m.employee_status = 'Active') DESC, m.id DESC SEPARATOR '||'), '||', 1
+        ) AS work_email
     FROM employee e
     JOIN employee m ON LOWER(e.manager_email) = LOWER(m.work_email)
     WHERE e.manager_email IS NOT NULL AND e.manager_email <> ''
-    GROUP BY m.work_email;`;
+    GROUP BY LOWER(m.work_email);`;
 
 # Check if a target employee is a direct or additional subordinate of a lead.
 #

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -88,7 +88,13 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
         e.work_location AS workLocation,
         e.start_date AS startDate,
         e.manager_email AS managerEmail,
-        COALESCE(CONCAT(mgr.first_name, ' ', mgr.last_name), '') AS managerName,
+        COALESCE((
+            SELECT CONCAT(m.first_name, ' ', m.last_name)
+            FROM employee m
+            WHERE LOWER(m.work_email) = LOWER(e.manager_email)
+            ORDER BY m.id DESC
+            LIMIT 1
+        ), '') AS managerName,
         COALESCE(eam.additionalManagerEmails, '') AS additionalManagerEmails,
         pi.gender AS gender,
         (
@@ -153,7 +159,6 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
         LEFT JOIN unit u ON e.unit_id = u.id
         LEFT JOIN house h ON e.house_id = h.id
         LEFT JOIN personal_info pi ON pi.id = e.personal_info_id
-        LEFT JOIN employee mgr ON LOWER(e.manager_email) = LOWER(mgr.work_email)
         LEFT JOIN employee csr ON csr.employee_id = e.continuous_service_record
         LEFT JOIN resignation r ON r.employee_id = e.id
     WHERE
@@ -180,7 +185,7 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
             e.work_location AS workLocation,
             e.start_date AS startDate,
             e.manager_email AS managerEmail,
-            COALESCE(CONCAT(mgr.first_name, ' ', mgr.last_name), '') AS managerName,
+            COALESCE(mgr.managerName, '') AS managerName,
             COALESCE(eam.additionalManagerEmails, '') AS additionalManagerEmails,
             COALESCE(sc.subordinateCount, 0) AS subordinateCount,
             e.employee_status AS employeeStatus,
@@ -253,7 +258,15 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
             LEFT JOIN sub_team st ON st.id = e.sub_team_id
             LEFT JOIN unit u ON u.id = e.unit_id
             LEFT JOIN house h ON h.id = e.house_id
-            LEFT JOIN employee mgr ON LOWER(e.manager_email) = LOWER(mgr.work_email)
+            LEFT JOIN (
+                SELECT
+                    LOWER(work_email) AS managerEmail,
+                    SUBSTRING_INDEX(
+                        GROUP_CONCAT(CONCAT(first_name, ' ', last_name) ORDER BY id DESC SEPARATOR '||'), '||', 1
+                    ) AS managerName
+                FROM employee
+                GROUP BY LOWER(work_email)
+            ) mgr ON mgr.managerEmail = LOWER(e.manager_email)
             LEFT JOIN employee csr ON csr.employee_id = e.continuous_service_record
             LEFT JOIN resignation r ON r.employee_id = e.id
         `;
@@ -372,12 +385,13 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
 #
 # + return - Parameterized query for fetching distinct managers
 isolated function getManagersQuery() returns sql:ParameterizedQuery =>
-    `SELECT DISTINCT 
-        m.employee_id, 
+    `SELECT
+        SUBSTRING_INDEX(GROUP_CONCAT(m.employee_id ORDER BY m.id DESC SEPARATOR '||'), '||', 1) AS employee_id,
         m.work_email
     FROM employee e
     JOIN employee m ON e.manager_email = m.work_email
-    WHERE e.manager_email IS NOT NULL AND e.manager_email <> '';`;
+    WHERE e.manager_email IS NOT NULL AND e.manager_email <> ''
+    GROUP BY m.work_email;`;
 
 # Check if a target employee is a direct or additional subordinate of a lead.
 #


### PR DESCRIPTION
## Purpose

The employees list was returning **duplicate employee rows** to the UI.

## Root cause

Duplicate `employee` records sharing the same `work_email` (surfaced by the ex-employee migration backfill) meant that the manager JOIN in `getEmployeesQuery` — `LEFT JOIN employee mgr ON LOWER(e.manager_email) = LOWER(mgr.work_email)` — matched more than one manager row per employee, multiplying each employee into several rows in the result set.

## Fix

`backend/modules/database/db_queries.bal`:

- **`getEmployeesQuery`** — replace the direct manager JOIN with a derived table that groups by `LOWER(work_email)` and picks the latest name by `id`, so every employee matches exactly one manager row.
- **`getEmployeeInfoQuery`** — replace the manager JOIN with a correlated subquery returning the latest manager name by `id` (`ORDER BY id DESC LIMIT 1`).
- **`getManagersQuery`** — switch `SELECT DISTINCT` to `GROUP BY m.work_email`, picking the latest `employee_id` by `id`, to avoid duplicate managers.

## Scope

Single-file, query-only change. No schema, API contract, or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manager name accuracy and consistency in employee records.
  * Ensured the most recent manager information is selected when duplicate or historical records exist.
  * Added safer handling for missing manager names, displaying a blank value instead of an incorrect result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->