### PR TITLE
People App - fix(employee): resolve continuous service date and surface it on Me page

### DIFF
--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -159,7 +159,7 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
         LEFT JOIN unit u ON e.unit_id = u.id
         LEFT JOIN house h ON e.house_id = h.id
         LEFT JOIN personal_info pi ON pi.id = e.personal_info_id
-        LEFT JOIN employee csr ON csr.employee_id = e.continuous_service_record
+        LEFT JOIN employee csr ON csr.id = e.continuous_service_record
         LEFT JOIN resignation r ON r.employee_id = e.id
     WHERE
         e.employee_id = ${employeeId};`;
@@ -267,7 +267,7 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
                 FROM employee
                 GROUP BY LOWER(work_email)
             ) mgr ON mgr.managerEmail = LOWER(e.manager_email)
-            LEFT JOIN employee csr ON csr.employee_id = e.continuous_service_record
+            LEFT JOIN employee csr ON csr.id = e.continuous_service_record
             LEFT JOIN resignation r ON r.employee_id = e.id
         `;
 

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -355,7 +355,7 @@ CREATE TABLE `employee` (
   CONSTRAINT `fk_emp_house`
     FOREIGN KEY (`house_id`) REFERENCES `house` (`id`),
   CONSTRAINT `fk_emp_continuous_service_record`
-    FOREIGN KEY (`continuous_service_record`) REFERENCES `employee` (`employee_id`)
+    FOREIGN KEY (`continuous_service_record`) REFERENCES `employee` (`id`)
 );
 
 -- Resignation table

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -315,7 +315,7 @@ CREATE TABLE `employee` (
   `job_role` VARCHAR(100) NULL,
   `manager_email` VARCHAR(254) NOT NULL,
   `employee_status` VARCHAR(50) NOT NULL,
-  `continuous_service_record` VARCHAR(99) NULL,
+  `continuous_service_record` INT NULL,
   `employee_thumbnail` VARCHAR(2048) NULL,
   `probation_end_date` DATE NULL,
   `last_promoted_date` DATE NULL,

--- a/apps/people-app/webapp/src/view/me/index.tsx
+++ b/apps/people-app/webapp/src/view/me/index.tsx
@@ -244,8 +244,11 @@ export default function Me({
   const [shouldRequireEmergencyContacts, setShouldRequireEmergencyContacts] =
     useState<boolean>(initialHasEmergencyContactsRef.current);
 
-  const serviceLength = employee?.startDate
-    ? calculateServiceLength(employee.startDate)
+  const serviceStartDate =
+    employee?.continuousServiceDate ?? employee?.startDate ?? null;
+
+  const serviceLength = serviceStartDate
+    ? calculateServiceLength(serviceStartDate)
     : null;
 
   const serviceText = formatServiceLength(serviceLength);
@@ -971,6 +974,16 @@ export default function Me({
                     {formatDate(employee.startDate, "-")}
                   </Typography>
                 </Grid>
+                {employee.continuousServiceDate && (
+                  <Grid item xs={12} sm={6} md={3}>
+                    <Typography color="text.secondary" sx={{ fontWeight: 500 }}>
+                      Continuous Service Date
+                    </Typography>
+                    <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                      {formatDate(employee.continuousServiceDate, "-")}
+                    </Typography>
+                  </Grid>
+                )}
                 <Grid item xs={12} sm={6} md={3}>
                   <Typography color="text.secondary" sx={{ fontWeight: 500 }}>
                     Length of Service


### PR DESCRIPTION
This pull request updates how the `continuous_service_record` field in the `employee` table is referenced and displayed, ensuring consistency across the backend, database schema, and frontend. It also improves how continuous service information is shown to users.

**Database and Backend Consistency:**

* Updated the foreign key constraint in the `employee` table so that `continuous_service_record` now references the `id` column instead of `employee_id` in the `employee` table.
* Modified SQL queries in `db_queries.bal` to join on `csr.id = e.continuous_service_record` instead of `csr.employee_id`, aligning with the schema change. [[1]](diffhunk://#diff-547b777293c675320a953537c65d8d91df6161fe3f64109a38572f7368fc6ce0L162-R162) [[2]](diffhunk://#diff-547b777293c675320a953537c65d8d91df6161fe3f64109a38572f7368fc6ce0L270-R270)

**Frontend Improvements:**

* Changed service length calculation in `Me` page to use `employee.continuousServiceDate` if available, falling back to `startDate` otherwise.
* Added display of the "Continuous Service Date" field in the employee profile if present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Continuous Service Date” field to employee general information when available.
  * Length of Service now reflects continuous service history, with the start date used as a fallback.

* **Bug Fixes**
  * Corrected continuous service record relationships so employee service dates display accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->