### PR TITLE
People App - feat(employee): add triggers to prevent self-referencing continuous_service_record and Format Dates 

### DIFF
--- a/apps/people-app/backend/Dependencies.toml
+++ b/apps/people-app/backend/Dependencies.toml
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "avro"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.11"
+version = "2.14.13"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -345,7 +345,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "confluent.cregistry"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -891,10 +891,11 @@ DELIMITER ;
 
 -- Trigger: trg_employee_no_self_continuous_service_insert
 -- continuous_service_record cannot reference the row's own id (MySQL disallows a
--- CHECK constraint on this column since `id` is AUTO_INCREMENT).
+-- CHECK constraint on this column since `id` is AUTO_INCREMENT). Must run AFTER
+-- INSERT: NEW.id is 0 in a BEFORE INSERT trigger since the value isn't generated yet.
 DELIMITER //
 CREATE TRIGGER `trg_employee_no_self_continuous_service_insert`
-BEFORE INSERT ON `employee`
+AFTER INSERT ON `employee`
 FOR EACH ROW
 BEGIN
   IF NEW.continuous_service_record IS NOT NULL AND NEW.continuous_service_record = NEW.id THEN

--- a/apps/people-app/backend/resources/people_app_creation.sql
+++ b/apps/people-app/backend/resources/people_app_creation.sql
@@ -889,6 +889,34 @@ BEGIN
 END//
 DELIMITER ;
 
+-- Trigger: trg_employee_no_self_continuous_service_insert
+-- continuous_service_record cannot reference the row's own id (MySQL disallows a
+-- CHECK constraint on this column since `id` is AUTO_INCREMENT).
+DELIMITER //
+CREATE TRIGGER `trg_employee_no_self_continuous_service_insert`
+BEFORE INSERT ON `employee`
+FOR EACH ROW
+BEGIN
+  IF NEW.continuous_service_record IS NOT NULL AND NEW.continuous_service_record = NEW.id THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'continuous_service_record cannot reference its own employee id';
+  END IF;
+END//
+DELIMITER ;
+
+-- Trigger: trg_employee_no_self_continuous_service_update
+DELIMITER //
+CREATE TRIGGER `trg_employee_no_self_continuous_service_update`
+BEFORE UPDATE ON `employee`
+FOR EACH ROW
+BEGIN
+  IF NEW.continuous_service_record IS NOT NULL AND NEW.continuous_service_record = NEW.id THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'continuous_service_record cannot reference its own employee id';
+  END IF;
+END//
+DELIMITER ;
+
 -- Procedure: prc_employee_additional_managers_audit
 DELIMITER //
 CREATE PROCEDURE `prc_employee_additional_managers_audit`(

--- a/apps/people-app/backend/resources/people_app_table_update_v1.0.20.sql
+++ b/apps/people-app/backend/resources/people_app_table_update_v1.0.20.sql
@@ -1,14 +1,16 @@
 -- Prevent an employee record from linking continuous_service_record to its own id.
 -- A CHECK constraint isn't usable here: MySQL rejects CHECK constraints that
 -- reference an AUTO_INCREMENT column (Error 3818, `id` is AUTO_INCREMENT), so
--- this is enforced with BEFORE INSERT/UPDATE triggers instead.
+-- this is enforced with INSERT/UPDATE triggers instead. The insert trigger must
+-- run AFTER INSERT: NEW.id is 0 in a BEFORE INSERT trigger since the value isn't
+-- generated yet.
 
 DROP TRIGGER IF EXISTS `trg_employee_no_self_continuous_service_insert`;
 DROP TRIGGER IF EXISTS `trg_employee_no_self_continuous_service_update`;
 
 DELIMITER //
 CREATE TRIGGER `trg_employee_no_self_continuous_service_insert`
-BEFORE INSERT ON `employee`
+AFTER INSERT ON `employee`
 FOR EACH ROW
 BEGIN
   IF NEW.continuous_service_record IS NOT NULL AND NEW.continuous_service_record = NEW.id THEN

--- a/apps/people-app/backend/resources/people_app_table_update_v1.0.20.sql
+++ b/apps/people-app/backend/resources/people_app_table_update_v1.0.20.sql
@@ -1,0 +1,31 @@
+-- Prevent an employee record from linking continuous_service_record to its own id.
+-- A CHECK constraint isn't usable here: MySQL rejects CHECK constraints that
+-- reference an AUTO_INCREMENT column (Error 3818, `id` is AUTO_INCREMENT), so
+-- this is enforced with BEFORE INSERT/UPDATE triggers instead.
+
+DROP TRIGGER IF EXISTS `trg_employee_no_self_continuous_service_insert`;
+DROP TRIGGER IF EXISTS `trg_employee_no_self_continuous_service_update`;
+
+DELIMITER //
+CREATE TRIGGER `trg_employee_no_self_continuous_service_insert`
+BEFORE INSERT ON `employee`
+FOR EACH ROW
+BEGIN
+  IF NEW.continuous_service_record IS NOT NULL AND NEW.continuous_service_record = NEW.id THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'continuous_service_record cannot reference its own employee id';
+  END IF;
+END//
+DELIMITER ;
+
+DELIMITER //
+CREATE TRIGGER `trg_employee_no_self_continuous_service_update`
+BEFORE UPDATE ON `employee`
+FOR EACH ROW
+BEGIN
+  IF NEW.continuous_service_record IS NOT NULL AND NEW.continuous_service_record = NEW.id THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'continuous_service_record cannot reference its own employee id';
+  END IF;
+END//
+DELIMITER ;

--- a/apps/people-app/webapp/package.json
+++ b/apps/people-app/webapp/package.json
@@ -105,5 +105,13 @@
   "devDependencies": {
     "@types/node": "^24.5.2",
     "react-app-rewired": "^2.2.1"
+  },
+  "overrides": {
+    "@mui/x-date-pickers": {
+      "date-fns": "$date-fns"
+    }
+  },
+  "resolutions": {
+    "@mui/x-date-pickers/date-fns": "^4.1.0"
   }
 }

--- a/apps/people-app/webapp/src/utils/utils.ts
+++ b/apps/people-app/webapp/src/utils/utils.ts
@@ -118,7 +118,7 @@ export const formatDate = (
   if (!isoDate) return fallback ?? null;
   const parsedDate = parseStrictYyyyMmDd(isoDate);
   if (!parsedDate) return fallback ?? null;
-  return format(parsedDate, "dd/MM/yyyy");
+  return format(parsedDate, "d MMM yyyy");
 };
 
 export const isPresentOrFuture = (isoDate?: string | null): boolean => {

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/Review.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/Review.tsx
@@ -17,9 +17,9 @@
 import React, { useMemo } from "react";
 import { Box, Grid, Typography, useTheme, alpha } from "@mui/material";
 import { useFormikContext } from "formik";
-import dayjs from "dayjs";
 import { useAppSelector } from "@slices/store";
 import { CreateEmployeeFormValues } from "@root/src/types/types";
+import { formatDate } from "@utils/utils";
 import {
   PersonOutline,
   CakeOutlined,
@@ -265,7 +265,7 @@ export default function ReviewStep() {
           <Grid item xs={12} sm={6} md={4}>
             <ReviewField
               label="Date of Birth"
-              value={p.dob ? dayjs(p.dob).format("MMMM D, YYYY") : null}
+              value={formatDate(p.dob)}
             />
           </Grid>
           <Grid item xs={12} sm={6} md={4}>
@@ -452,31 +452,19 @@ export default function ReviewStep() {
           <Grid item xs={12} sm={6} md={4}>
             <ReviewField
               label="Start Date"
-              value={
-                values.startDate
-                  ? dayjs(values.startDate).format("MMMM D, YYYY")
-                  : null
-              }
+              value={formatDate(values.startDate)}
             />
           </Grid>
           <Grid item xs={12} sm={6} md={4}>
             <ReviewField
               label="Probation End Date"
-              value={
-                values.probationEndDate
-                  ? dayjs(values.probationEndDate).format("MMMM D, YYYY")
-                  : null
-              }
+              value={formatDate(values.probationEndDate)}
             />
           </Grid>
           <Grid item xs={12} sm={6} md={4}>
             <ReviewField
               label="Agreement End Date"
-              value={
-                values.agreementEndDate
-                  ? dayjs(values.agreementEndDate).format("MMMM D, YYYY")
-                  : null
-              }
+              value={formatDate(values.agreementEndDate)}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
This pull request introduces several improvements across backend and frontend for the people-app, focusing on data integrity, dependency updates, and UI consistency. The most significant changes are the addition of database triggers to enforce data integrity, updates to backend dependencies, and UI/utility adjustments for consistent date formatting.

**Database integrity enforcement:**

* Added MySQL triggers (`trg_employee_no_self_continuous_service_insert` and `trg_employee_no_self_continuous_service_update`) to prevent an employee's `continuous_service_record` from referencing its own `id`, ensuring data consistency where CHECK constraints cannot be used due to MySQL limitations. [[1]](diffhunk://#diff-8130009565764d8f47b29f708bd3a29f47ed7151d719fd0d131c68bebd63ea39R892-R920) [[2]](diffhunk://#diff-8c7bf4db212f0ac62755ac9c7b406d1409fd00e6f9125d3159be3e2ed13b5aecR1-R33)

**Backend dependency updates:**

* Updated several Ballerina package versions in `Dependencies.toml` to address bug fixes and improvements, including `avro` (1.2.2), `http` (2.14.13), `time` (2.8.1), `url` (2.6.2), and `confluent.cregistry` (0.4.5). [[1]](diffhunk://#diff-ded936e559282c20d5a14590cd24e73f4165f8c869bc4de3f1e3f2548335b0d9L25-R25) [[2]](diffhunk://#diff-ded936e559282c20d5a14590cd24e73f4165f8c869bc4de3f1e3f2548335b0d9L96-R96) [[3]](diffhunk://#diff-ded936e559282c20d5a14590cd24e73f4165f8c869bc4de3f1e3f2548335b0d9L337-R337) [[4]](diffhunk://#diff-ded936e559282c20d5a14590cd24e73f4165f8c869bc4de3f1e3f2548335b0d9L348-R348) [[5]](diffhunk://#diff-ded936e559282c20d5a14590cd24e73f4165f8c869bc4de3f1e3f2548335b0d9L434-R434)

**Frontend dependency and UI improvements:**

* Added `overrides` and `resolutions` in `package.json` to ensure consistent versions of `date-fns` for `@mui/x-date-pickers`, improving date handling reliability.
* Replaced all usages of `dayjs` for date formatting in the onboarding review step with a single `formatDate` utility function, ensuring consistent date display throughout the UI. [[1]](diffhunk://#diff-9c739d43a4c8deb6e60dea2bb94a28412f0b77ce4248e5ecf42d50969ef806a6L20-R22) [[2]](diffhunk://#diff-9c739d43a4c8deb6e60dea2bb94a28412f0b77ce4248e5ecf42d50969ef806a6L268-R268) [[3]](diffhunk://#diff-9c739d43a4c8deb6e60dea2bb94a28412f0b77ce4248e5ecf42d50969ef806a6L455-R467)
* Updated the `formatDate` utility to use the format `d MMM yyyy` (e.g., `1 Jan 2024`) instead of `dd/MM/yyyy`, improving date readability.