### PR TITLE
People App - feat(employee): add formatted start date column to My Team table

### DIFF
--- a/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
+++ b/apps/people-app/webapp/src/view/employees/myTeam/MyTeamTable.tsx
@@ -35,7 +35,7 @@ import { State } from "@src/types/types";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { MyTeamSearchForm } from "./MyTeamSearchForm";
-import { getEmployeeStatusColor } from "@utils/utils";
+import { formatDate, getEmployeeStatusColor } from "@utils/utils";
 
 export default function MyTeamTable() {
   const theme = useTheme();
@@ -211,6 +211,16 @@ export default function MyTeamTable() {
               {params.value || "N/A"}
             </Box>
           </Tooltip>
+        ),
+      },
+      {
+        field: "startDate",
+        headerName: "Start Date",
+        width: 120,
+        resizable: false,
+        valueGetter: (_value, row) => formatDate(row.startDate, "-"),
+        renderCell: (params: GridRenderCellParams<Employee>) => (
+          <Box sx={{ color: theme.palette.text.primary }}>{params.value}</Box>
         ),
       },
       {


### PR DESCRIPTION
## Summary
- Leads viewing My Team previously had no date visibility for their reports, unlike the admin Employees table which already shows a formatted Start Date column.
- Added a Start Date column to `MyTeamTable.tsx` using the shared `formatDate` util (`D MMM YYYY`), matching the existing convention in `EmployeesTable.tsx`.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually verify the My Team table (lead role) shows Start Date formatted as e.g. `27 Jul 2026`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Start Date** column to the employee team table.
  * Start dates are displayed in a consistent, user-friendly format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->