### PR TITLE
[People App] Allow resignation details for Marked leaver employees

### DIFF
--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -791,6 +791,8 @@ isolated function syncResignationRecord(string employeeId, UpdateEmployeeJobInfo
 
     if hasLeaverFields(payload) {
         _ = check databaseClient->execute(upsertResignationQuery(employeeId, payload, updatedBy));
+    }
+    if payload.employeeStatus == EMPLOYEE_LEFT {
         check inactivateEmployeeRelationshipsOnOffboarding(employeeId, updatedBy);
     }
 }

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -738,7 +738,11 @@ public isolated function updateEmployeeJobInfo(string employeeId, UpdateEmployee
         sql:ExecutionResult executionResult =
             check databaseClient->execute(updateEmployeeJobInfoQuery(employeeId, payload, updatedBy));
 
-        check checkAffectedCount(executionResult.affectedRowCount);
+        // A resignation-only payload updates just `updated_by` on the employee row; the real change
+        // lands in the resignation table below, so a zero affected count is not an error for it.
+        if !hasLeaverFields(payload) {
+            check checkAffectedCount(executionResult.affectedRowCount);
+        }
 
         Email[]? additionalManagerEmails = payload.additionalManagerEmails;
         if additionalManagerEmails is Email[] {

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -1533,13 +1533,17 @@ service http:InterceptableService / on new http:Listener(9090) {
             }
         }
 
-        if database:hasLeaverFields(payload) && payload.employeeStatus != database:EMPLOYEE_LEFT
-                && employeeInfo.employeeStatus != database:EMPLOYEE_LEFT {
-            log:printWarn("Attempt to set resignation fields on a non-Left employee",
+        boolean isLeaverStatus = payload.employeeStatus is ()
+            ? employeeInfo.employeeStatus == database:EMPLOYEE_LEFT
+                || employeeInfo.employeeStatus == database:EMPLOYEE_MARKED_LEAVER
+            : payload.employeeStatus == database:EMPLOYEE_LEFT
+                || payload.employeeStatus == database:EMPLOYEE_MARKED_LEAVER;
+        if database:hasLeaverFields(payload) && !isLeaverStatus {
+            log:printWarn("Attempt to set resignation fields on an employee who is not a leaver",
                     employeeId = employeeId);
             return <http:BadRequest>{
                 body: {
-                    message: "Resignation details can only be set when employee status is 'Left'"
+                    message: "Resignation details can only be set when employee status is 'Left' or 'Marked leaver'"
                 }
             };
         }

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -593,6 +593,10 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
     );
   }, [internshipTypeId, values.employmentTypeId]);
 
+  const isLeaverStatus =
+    values.employeeStatus === EmployeeStatus.Left ||
+    values.employeeStatus === EmployeeStatus.MarkedLeaver;
+
   const isFixedTerm = useMemo(() => {
     const selectedType = employmentTypes.find(
       (et) => et.id === values.employmentTypeId,
@@ -1432,7 +1436,10 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                 onChange={(e) => {
                   const newStatus = e.target.value;
                   setFieldValue("employeeStatus", newStatus);
-                  if (newStatus !== EmployeeStatus.Left) {
+                  if (
+                    newStatus !== EmployeeStatus.Left &&
+                    newStatus !== EmployeeStatus.MarkedLeaver
+                  ) {
                     setFieldValue("finalDayInOffice", null);
                     setFieldValue("finalDayOfEmployment", null);
                     setFieldValue("resignationReason", null);
@@ -1766,7 +1773,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
             <Grid item xs={12} sm={6} md={4}>
               <DatePicker
                 label="Final Day in Office"
-                disabled={values.employeeStatus !== EmployeeStatus.Left}
+                disabled={!isLeaverStatus}
                 value={
                   values.finalDayInOffice
                     ? dayjs(values.finalDayInOffice)
@@ -1791,7 +1798,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
             <Grid item xs={12} sm={6} md={4}>
               <DatePicker
                 label="Final Day of Employment"
-                disabled={values.employeeStatus !== EmployeeStatus.Left}
+                disabled={!isLeaverStatus}
                 value={
                   values.finalDayOfEmployment
                     ? dayjs(values.finalDayOfEmployment)
@@ -1818,7 +1825,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
                 fullWidth
                 label="Reason for Leaving"
                 name="resignationReason"
-                disabled={values.employeeStatus !== EmployeeStatus.Left}
+                disabled={!isLeaverStatus}
                 value={values.resignationReason ?? ""}
                 onChange={(e) =>
                   setFieldValue(


### PR DESCRIPTION
## Purpose

In the employee edit form, the resignation details (Final Day in Office, Final Day of Employment, Reason for Leaving) were only editable when the employee status was **Left**. Employees who are **Marked leaver** also need their resignation details recorded ahead of their departure, but the form disabled the fields and the backend rejected them.

## Changes

**Webapp (`JobInfo.tsx`)**
- The three resignation fields are enabled when the status is **Left** or **Marked leaver** (shared `isLeaverStatus` flag).
- The Employee Status dropdown clears the resignation fields only when switching to a non-leaver status.

**Backend**
- `service.bal`: the guard now accepts resignation fields when the (new or existing) employee status is **Left** or **Marked leaver**; when the payload changes the status, the payload value is what counts.
- `db_functions.bal` (`syncResignationRecord`): the resignation record upsert still runs whenever resignation fields are present, but the offboarding side effect (`inactivateEmployeeRelationshipsOnOffboarding`) now fires only when the payload actually sets the status to **Left**. Recording resignation details for a Marked leaver (still working) no longer inactivates their additional-manager relationships prematurely, while the inactivation still happens on the real offboarding transition.

## Checklist
- [x] Webapp type-checks cleanly (`tsc --noEmit`)
- [ ] Backend build verified via CI (local bal version cannot build this package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)