### PR TITLE
People App: support employee rehires, Probation onboarding, and job band display

### DIFF
--- a/apps/people-app/backend/Dependencies.toml
+++ b/apps/people-app/backend/Dependencies.toml
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -520,11 +520,16 @@ isolated function generateBulkEmployeeId(CreateEmployeePayload payload,
                 return error(string `Company (ID: ${payload.companyId}) has no employee ID prefix configured`);
             }
             // PERMANENT and PROBATION share one number line; INTERNSHIP runs a separate one.
-            // Scope both the MAX query and the in-batch cache key to the matching group.
+            // Scope both the MAX query and the in-batch cache key to the matching group — using
+            // employmentType.toString() directly here would give PERMANENT and PROBATION rows
+            // separate cache entries and let interleaved batch rows collide on the same ID.
             EmploymentTypeName[] sequenceTypes = context.employmentType == INTERNSHIP
                 ? [INTERNSHIP]
                 : [PERMANENT, PROBATION];
-            string seqKey = companyPrefix + ":" + context.employmentType.toString();
+            string sequenceGroup = context.employmentType == INTERNSHIP
+                ? INTERNSHIP.toString()
+                : "PERMANENT_PROBATION";
+            string seqKey = companyPrefix + ":" + sequenceGroup;
             if !sequenceCache.hasKey(seqKey) {
                 EmployeeIdSequence seq = check getLastEmployeeNumericSuffix(
                         companyPrefix, sequenceTypes);

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -584,8 +584,12 @@ public isolated function getLastEmployeeNumericSuffix(string prefix, EmploymentT
 # + createdBy - Creator of the personal info record
 # + return - Created personal info ID or error
 isolated function addPersonalInfo(CreatePersonalInfoPayload personalInfo, string createdBy) returns int|error {
-    sql:ExecutionResult result = check databaseClient->execute(addEmployeePersonalInfoQuery(personalInfo, createdBy));
-    return check result.lastInsertId.ensureType(int);
+    _ = check databaseClient->execute(addEmployeePersonalInfoQuery(personalInfo, createdBy));
+    // Not result.lastInsertId: the personal_info_audit AFTER trigger's own auto-increment
+    // insert makes the JDBC driver's generated-keys result unreliable (returns nil) once that
+    // trigger fires. LAST_INSERT_ID() queried explicitly on this connection is unaffected.
+    record {|int id;|} row = check databaseClient->queryRow(`SELECT LAST_INSERT_ID() AS id`);
+    return row.id;
 }
 
 # Add employee record.

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -62,6 +62,15 @@ public isolated function hasEmployeeWithWorkEmail(int personalInfoId, string wor
     return count > 0;
 }
 
+# Check whether a personal_info ID has any currently active employment.
+#
+# + personalInfoId - personal_info ID matched by NIC/Passport
+# + return - true if an active employee record references this personal_info ID, or error
+public isolated function hasActiveEmploymentByPersonalInfoId(int personalInfoId) returns boolean|error {
+    int count = check databaseClient->queryRow(countActiveEmployeeByPersonalInfoIdQuery(personalInfoId));
+    return count > 0;
+}
+
 # Fetch employee detailed information.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -115,19 +115,6 @@ public isolated function getContinuousServiceRecordsByEmail(string workEmail)
         select serviceRecord;
 }
 
-# Search employee personal information.
-#
-# + payload - Search employee personal information payload
-# + return - Employee personal information search results
-public isolated function searchEmployeePersonalInfo(SearchEmployeePersonalInfoPayload payload)
-    returns EmployeePersonalInfo[]|error {
-
-    stream<EmployeePersonalInfo, error?> employeePersonalInfoStream = databaseClient->query(
-            searchEmployeePersonalInfoQuery(payload));
-    return from EmployeePersonalInfo employeePersonalInfo in employeePersonalInfoStream
-        select employeePersonalInfo;
-}
-
 # Fetch employee personal information.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -43,6 +43,25 @@ public isolated function getEmployeeIdByEpf(string epf) returns string|error? {
     return result is sql:NoRowsError ? () : result;
 }
 
+# Get the personal_info ID for a given NIC/Passport.
+#
+# + nicOrPassport - National Identity Card number or Passport
+# + return - personal_info ID, nil if no matching record, or error
+public isolated function getPersonalInfoIdByNic(string nicOrPassport) returns int?|error {
+    int|error result = databaseClient->queryRow(getPersonalInfoIdByNicQuery(nicOrPassport));
+    return result is sql:NoRowsError ? () : result;
+}
+
+# Check whether a personal_info ID already has an employee record under the given work email.
+#
+# + personalInfoId - personal_info ID matched by NIC/Passport
+# + workEmail - Work email from the new onboarding submission
+# + return - true if a matching employee record exists, or error
+public isolated function hasEmployeeWithWorkEmail(int personalInfoId, string workEmail) returns boolean|error {
+    int count = check databaseClient->queryRow(countEmployeeByPersonalInfoIdAndWorkEmailQuery(personalInfoId, workEmail));
+    return count > 0;
+}
+
 # Fetch employee detailed information.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -516,7 +516,7 @@ isolated function generateBulkEmployeeId(CreateEmployeePayload payload,
     }
 
     match context.employmentType {
-        PERMANENT|INTERNSHIP => {
+        PERMANENT|INTERNSHIP|PROBATION => {
             // Normalize the prefix once so a value like " SG " can't pass the guard, leak spaces
             // into the ID, or fork a separate sequence from "SG".
             string companyPrefix = context.companyPrefix.trim();
@@ -524,11 +524,10 @@ isolated function generateBulkEmployeeId(CreateEmployeePayload payload,
                 return error(string `Company (ID: ${payload.companyId}) has no employee ID prefix configured`);
             }
             // PERMANENT and PROBATION share one number line; INTERNSHIP runs a separate one.
-            // Scope both the MAX query and the in-batch cache key to the matching group. PROBATION
-            // never reaches this path (inactive types are rejected during bulk validation).
-            EmploymentTypeName[] sequenceTypes = context.employmentType == PERMANENT
-                ? [PERMANENT, PROBATION]
-                : [INTERNSHIP];
+            // Scope both the MAX query and the in-batch cache key to the matching group.
+            EmploymentTypeName[] sequenceTypes = context.employmentType == INTERNSHIP
+                ? [INTERNSHIP]
+                : [PERMANENT, PROBATION];
             string seqKey = companyPrefix + ":" + context.employmentType.toString();
             if !sequenceCache.hasKey(seqKey) {
                 EmployeeIdSequence seq = check getLastEmployeeNumericSuffix(

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -83,6 +83,14 @@ isolated function countEmployeeByPersonalInfoIdAndWorkEmailQuery(int personalInf
      WHERE personal_info_id = ${personalInfoId}
        AND LOWER(work_email) = LOWER(${workEmail});`;
 
+# Count active employee records linked to a personal_info ID — used to block onboarding a
+# rehire for someone who is still currently employed.
+#
+# + personalInfoId - personal_info ID matched by NIC/Passport
+# + return - Query returning the count of active employee records
+isolated function countActiveEmployeeByPersonalInfoIdQuery(int personalInfoId) returns sql:ParameterizedQuery =>
+    `SELECT COUNT(*) FROM employee WHERE personal_info_id = ${personalInfoId} AND employee_status = ${EMPLOYEE_ACTIVE};`;
+
 # Fetch employee work email by employee ID.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -1299,8 +1299,8 @@ isolated function getHousesWithActiveEmployeeCountsQuery() returns sql:Parameter
 
 # Add employee personal information query. Upserts on the nic_or_passport UNIQUE key so
 # rehiring someone (same NIC/Passport) refreshes their existing personal_info row instead of
-# failing — `id = LAST_INSERT_ID(id)` makes the update branch still hand back that row's own id,
-# so the caller's `result.lastInsertId` is the existing id, not 0.
+# failing — `id = LAST_INSERT_ID(id)` makes the update branch still resolve to that row's own
+# id when the caller queries `SELECT LAST_INSERT_ID()` afterward (see addPersonalInfo).
 #
 # + payload - Create personal info payload
 # + createdBy - Creator/updater of the personal info record

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -64,6 +64,25 @@ isolated function getEmployeeIdQuery(int id) returns sql:ParameterizedQuery =>
 isolated function getEmployeeIdByEpfQuery(string epf) returns sql:ParameterizedQuery =>
     `SELECT employee_id FROM employee WHERE epf = ${epf} LIMIT 1;`;
 
+# Fetch the personal_info ID for a given NIC/Passport.
+#
+# + nicOrPassport - National Identity Card number or Passport
+# + return - Query returning the personal_info ID
+isolated function getPersonalInfoIdByNicQuery(string nicOrPassport) returns sql:ParameterizedQuery =>
+    `SELECT id FROM personal_info WHERE nic_or_passport = ${nicOrPassport} LIMIT 1;`;
+
+# Check whether a personal_info ID already has an employee record under the given work email —
+# used to confirm a duplicate NIC/Passport belongs to the same person coming back (rehire).
+#
+# + personalInfoId - personal_info ID matched by NIC/Passport
+# + workEmail - Work email from the new onboarding submission
+# + return - Query returning the count of matching employee records
+isolated function countEmployeeByPersonalInfoIdAndWorkEmailQuery(int personalInfoId, string workEmail)
+    returns sql:ParameterizedQuery =>
+    `SELECT COUNT(*) FROM employee
+     WHERE personal_info_id = ${personalInfoId}
+       AND LOWER(work_email) = LOWER(${workEmail});`;
+
 # Fetch employee work email by employee ID.
 #
 # + employeeId - Employee ID
@@ -1304,11 +1323,14 @@ isolated function getHousesWithActiveEmployeeCountsQuery() returns sql:Parameter
      GROUP BY h.id, h.name
      ORDER BY active_count ASC`;
 
-# Add employee personal information query.
+# Add employee personal information query. Upserts on the nic_or_passport UNIQUE key so
+# rehiring someone (same NIC/Passport) refreshes their existing personal_info row instead of
+# failing — `id = LAST_INSERT_ID(id)` makes the update branch still hand back that row's own id,
+# so the caller's `result.lastInsertId` is the existing id, not 0.
 #
 # + payload - Create personal info payload
-# + createdBy - Creator of the personal info record
-# + return - Personal info insert query
+# + createdBy - Creator/updater of the personal info record
+# + return - Personal info upsert query
 isolated function addEmployeePersonalInfoQuery(CreatePersonalInfoPayload payload, string createdBy)
     returns sql:ParameterizedQuery =>
     `INSERT INTO personal_info
@@ -1354,7 +1376,26 @@ isolated function addEmployeePersonalInfoQuery(CreatePersonalInfoPayload payload
             ${payload.nationality},
             ${createdBy},
             ${createdBy}
-        );`;
+        )
+    ON DUPLICATE KEY UPDATE
+        id = LAST_INSERT_ID(id),
+        first_name = VALUES(first_name),
+        last_name = VALUES(last_name),
+        full_name = VALUES(full_name),
+        title = VALUES(title),
+        dob = VALUES(dob),
+        gender = VALUES(gender),
+        personal_email = VALUES(personal_email),
+        personal_phone = VALUES(personal_phone),
+        resident_number = VALUES(resident_number),
+        address_line_1 = VALUES(address_line_1),
+        address_line_2 = VALUES(address_line_2),
+        city = VALUES(city),
+        state_or_province = VALUES(state_or_province),
+        postal_code = VALUES(postal_code),
+        country = VALUES(country),
+        nationality = VALUES(nationality),
+        updated_by = ${createdBy};`;
 
 # Fetch company prefix and employment type required for generating the next employee ID.
 #

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -522,40 +522,6 @@ isolated function getContinuousServiceRecordQuery(string workEmail) returns sql:
         AND et.is_active = 1
         AND et.name IN ('Permanent');`;
 
-# Search employee personal information.
-#
-# + payload - Search employee personal information payload
-# + return - Query to search employee personal information
-isolated function searchEmployeePersonalInfoQuery(SearchEmployeePersonalInfoPayload payload)
-    returns sql:ParameterizedQuery {
-    sql:ParameterizedQuery mainQuery = `
-        SELECT 
-            nic_or_passport,
-            p.first_name AS firstName,
-            p.last_name AS lastName,
-            full_name,
-            title,
-            dob,
-            gender,
-            personal_email,
-            personal_phone,
-            resident_number,
-            address_line_1,
-            address_line_2,
-            city,
-            state_or_province,
-            postal_code,
-            country,
-            nationality
-        FROM personal_info p`;
-
-    string? nicOrPassport = payload?.nicOrPassport;
-    if nicOrPassport is string {
-        mainQuery = sql:queryConcat(mainQuery, ` WHERE p.nic_or_passport = ${nicOrPassport}`);
-    }
-    return sql:queryConcat(mainQuery, `;`);
-}
-
 # Fetch employee personal information.
 #
 # + employeeId - Employee ID

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -674,12 +674,6 @@ public type EpfRow record {|
     string epf;
 |};
 
-# Search employee personal information payload.
-public type SearchEmployeePersonalInfoPayload record {|
-    # National Identity Card number or Passport
-    string nicOrPassport?;
-|};
-
 # Emergency contact information.
 public type EmergencyContact record {|
     # Name of the emergency contact

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -1208,25 +1208,39 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        database:EmployeePersonalInfo[]|error employeePersonalInfoList = database:searchEmployeePersonalInfo(
-                {nicOrPassport: payload.personalInfo.nicOrPassport});
-        if employeePersonalInfoList is error {
+        int?|error existingPersonalInfoId = database:getPersonalInfoIdByNic(payload.personalInfo.nicOrPassport);
+        if existingPersonalInfoId is error {
             string customErr = "Error occurred while checking existing employee personal information";
-            log:printError(customErr, employeePersonalInfoList, nicOrPassport = payload.personalInfo.nicOrPassport);
+            log:printError(customErr, existingPersonalInfoId, nicOrPassport = payload.personalInfo.nicOrPassport);
             return <http:InternalServerError>{
                 body: {
                     message: ERROR_EMPLOYEE_CREATION_FAILED
                 }
             };
         }
-        if employeePersonalInfoList.length() > 0 {
-            string customErr = "Employee with the given NIC/Passport already exists";
-            log:printWarn(customErr, nicOrPassport = payload.personalInfo.nicOrPassport);
-            return <http:BadRequest>{
-                body: {
-                    message: customErr
-                }
-            };
+        if existingPersonalInfoId is int {
+            boolean|error isSameEmployee = database:hasEmployeeWithWorkEmail(existingPersonalInfoId, payload.workEmail);
+            if isSameEmployee is error {
+                string customErr = "Error occurred while verifying rehire eligibility";
+                log:printError(customErr, isSameEmployee, nicOrPassport = payload.personalInfo.nicOrPassport);
+                return <http:InternalServerError>{
+                    body: {
+                        message: ERROR_EMPLOYEE_CREATION_FAILED
+                    }
+                };
+            }
+            if !isSameEmployee {
+                string customErr = "Employee with the given NIC/Passport already exists";
+                log:printWarn(customErr, nicOrPassport = payload.personalInfo.nicOrPassport);
+                return <http:BadRequest>{
+                    body: {
+                        message: customErr
+                    }
+                };
+            }
+            // NIC/Passport matches a prior employee record under the same work email — this is
+            // a rehire. Fall through and let addEmployee's upsert refresh their personal_info
+            // row and link the new employee record to that same personal_info ID.
         }
 
         string? epfOpt = payload.epf;

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -1219,6 +1219,26 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
         if existingPersonalInfoId is int {
+            boolean|error hasActiveEmployment = database:hasActiveEmploymentByPersonalInfoId(existingPersonalInfoId);
+            if hasActiveEmployment is error {
+                string customErr = "Error occurred while checking existing employee status";
+                log:printError(customErr, hasActiveEmployment, nicOrPassport = payload.personalInfo.nicOrPassport);
+                return <http:InternalServerError>{
+                    body: {
+                        message: ERROR_EMPLOYEE_CREATION_FAILED
+                    }
+                };
+            }
+            if hasActiveEmployment {
+                string customErr = "Employee with the given NIC/Passport already exists";
+                log:printWarn(customErr, nicOrPassport = payload.personalInfo.nicOrPassport);
+                return <http:BadRequest>{
+                    body: {
+                        message: customErr
+                    }
+                };
+            }
+
             boolean|error isSameEmployee = database:hasEmployeeWithWorkEmail(existingPersonalInfoId, payload.workEmail);
             if isSameEmployee is error {
                 string customErr = "Error occurred while verifying rehire eligibility";
@@ -1238,9 +1258,9 @@ service http:InterceptableService / on new http:Listener(9090) {
                     }
                 };
             }
-            // NIC/Passport matches a prior employee record under the same work email — this is
-            // a rehire. Fall through and let addEmployee's upsert refresh their personal_info
-            // row and link the new employee record to that same personal_info ID.
+            // NIC/Passport belongs to a former employee (no active employment) under the same
+            // work email — this is a rehire. Fall through and let addEmployee's upsert refresh
+            // their personal_info row and link the new employee record to that same personal_info ID.
         }
 
         string? epfOpt = payload.epf;

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -41,9 +41,8 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
         };
     }
 
-    // Reject inactive employment types (e.g. PROBATION). The frontend already hides them, but a
-    // direct API call could still send one; without this it would fall through to the unsupported
-    // 500 path. PROBATION stays non-onboardable here yet is still counted in the PERMANENT line below.
+    // Reject inactive employment types. The frontend already hides them, but a direct API call
+    // could still send one; without this it would fall through to the unsupported 500 path.
     if !ctx.isActive {
         string customErr = string `Employment type (ID: ${payload.employmentTypeId}) is inactive ` +
             "and cannot be used for onboarding.";
@@ -60,7 +59,7 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
     string companyPrefix = ctx.companyPrefix.trim();
 
     match ctx.employmentType {
-        database:PERMANENT|database:INTERNSHIP => {
+        database:PERMANENT|database:INTERNSHIP|database:PROBATION => {
             if companyPrefix.length() == 0 {
                 string customErr = string `The selected company (ID: ${payload.companyId}) has no employee ` +
                     "ID prefix configured. Set the company prefix before onboarding.";
@@ -72,12 +71,10 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
                 };
             }
             // PERMANENT and PROBATION share one number line (an employee keeps the same ID across
-            // probation -> permanent); INTERNSHIP runs a separate line. PROBATION is intentionally
-            // counted here but not onboardable (rejected by the is_active check above) -- do not add
-            // a PROBATION match arm or re-key this ternary off it.
-            database:EmploymentTypeName[] sequenceTypes = ctx.employmentType == database:PERMANENT
-                ? [database:PERMANENT, database:PROBATION]
-                : [database:INTERNSHIP];
+            // probation -> permanent); INTERNSHIP runs a separate line.
+            database:EmploymentTypeName[] sequenceTypes = ctx.employmentType == database:INTERNSHIP
+                ? [database:INTERNSHIP]
+                : [database:PERMANENT, database:PROBATION];
             database:EmployeeIdSequence|error row = database:getLastEmployeeNumericSuffix(
                     companyPrefix, sequenceTypes
             );
@@ -238,7 +235,7 @@ isolated function loadBulkReferenceData() returns BulkRefData|error {
         designationIds: map from database:Designation d_row in designations
             select [normalizeKey(d_row.designation), d_row.id],
         // Only active types are valid for onboarding; mirrors the frontend filter so a CSV row
-        // naming an inactive type (e.g. PROBATION) is rejected during validation.
+        // naming an inactive employment type is rejected during validation.
         employmentTypeIds: map from database:EmploymentType et_row in employmentTypes
             where et_row.isActive
             select [normalizeKey(et_row.name), et_row.id],

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -41,8 +41,8 @@ public isolated function generateEmployeeId(database:CreateEmployeePayload paylo
         };
     }
 
-    // Reject inactive employment types. The frontend already hides them, but a direct API call
-    // could still send one; without this it would fall through to the unsupported 500 path.
+    // Reject inactive employment types before ID generation. The frontend already hides them,
+    // but a direct API call could still submit an inactive (yet otherwise supported) type.
     if !ctx.isActive {
         string customErr = string `Employment type (ID: ${payload.employmentTypeId}) is inactive ` +
             "and cannot be used for onboarding.";

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -652,6 +652,11 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
   }, [values.companyId, values.workLocation, companies]);
 
   useEffect(() => {
+    // Wait for employment types to load — isPermanent/isProbationType both read
+    // false on an empty list, which would otherwise clear an edit-mode value
+    // (loaded from the employee record) before the preservation guard below runs.
+    if (employmentTypes.length === 0) return;
+
     // Permanent and Probation both derive their probation end date from the
     // work location's configured probation period.
     if (!isPermanent && !isProbationType) {
@@ -687,6 +692,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
     // (including from the picker below) and immediately overwrites it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    employmentTypes.length,
     isPermanent,
     isProbationType,
     isEditMode,
@@ -1235,11 +1241,16 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
             >
               {designations.length ? (
                 [...designations]
-                  .sort((a, b) => (a.jobBand ?? Infinity) - (b.jobBand ?? Infinity))
+                  .sort((a, b) => {
+                    if (a.jobBand == null && b.jobBand == null) return 0;
+                    if (a.jobBand == null) return 1;
+                    if (b.jobBand == null) return -1;
+                    return a.jobBand - b.jobBand;
+                  })
                   .map((d) => (
                     <MenuItem key={d.id} value={d.id}>
                       {d.designation}
-                      {d.jobBand ? ` (JB ${d.jobBand})` : ""}
+                      {d.jobBand != null ? ` (JB ${d.jobBand})` : ""}
                     </MenuItem>
                   ))
               ) : (

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -362,9 +362,11 @@ const InfoPopoverAdornment = React.memo(
 );
 
 export const AUTO_ID_EMPLOYMENT_TYPES =
-  /^(permanent|internship|consultancy|advisory consultancy|part time consultancy)$/i;
+  /^(permanent|internship|consultancy|advisory consultancy|part time consultancy|probation)$/i;
 
 export const FIXED_TERM_EMPLOYMENT_TYPE = /^fixed\s+term\s+contract$/i;
+
+export const PROBATION_EMPLOYMENT_TYPE = /^probation$/i;
 
 export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
   const theme = useTheme();
@@ -605,6 +607,14 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
     return FIXED_TERM_EMPLOYMENT_TYPE.test(selectedType.name.trim());
   }, [employmentTypes, values.employmentTypeId]);
 
+  const isProbationType = useMemo(() => {
+    const selectedType = employmentTypes.find(
+      (et) => et.id === values.employmentTypeId,
+    );
+    if (!selectedType) return false;
+    return PROBATION_EMPLOYMENT_TYPE.test(selectedType.name.trim());
+  }, [employmentTypes, values.employmentTypeId]);
+
   const showAgreementEndDate = useMemo(() => {
     const normalized = employmentTypes
       .find((e) => e.id === values.employmentTypeId)
@@ -642,7 +652,9 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
   }, [values.companyId, values.workLocation, companies]);
 
   useEffect(() => {
-    if (!isPermanent) {
+    // Permanent and Probation both derive their probation end date from the
+    // work location's configured probation period.
+    if (!isPermanent && !isProbationType) {
       setFieldValue("probationEndDate", null);
       return;
     }
@@ -670,11 +682,15 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
       .add(probationMonths, "month")
       .format("YYYY-MM-DD");
     setFieldValue("probationEndDate", computed);
+    // values.probationEndDate is read above (edit-mode guard) but deliberately
+    // excluded here — including it re-fires this effect on every manual edit
+    // (including from the picker below) and immediately overwrites it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isPermanent,
+    isProbationType,
     isEditMode,
     values.startDate,
-    values.probationEndDate,
     matchedProbationLocation,
     setFieldValue,
   ]);
@@ -1514,7 +1530,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               }}
             />
           </Grid>
-          {isPermanent ? (
+          {isPermanent || isProbationType ? (
             <Grid item xs={12} sm={6} md={3}>
               <DatePicker
                 label="Probation End Date"

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -1234,11 +1234,14 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               }}
             >
               {designations.length ? (
-                sortAndFormatOptions(designations, (d) => d.designation).map((d) => (
-                  <MenuItem key={d.id} value={d.id}>
-                    {d.designation}
-                  </MenuItem>
-                ))
+                [...designations]
+                  .sort((a, b) => (a.jobBand ?? Infinity) - (b.jobBand ?? Infinity))
+                  .map((d) => (
+                    <MenuItem key={d.id} value={d.id}>
+                      {d.designation}
+                      {d.jobBand ? ` (JB ${d.jobBand})` : ""}
+                    </MenuItem>
+                  ))
               ) : (
                 <MenuItem disabled>
                   {!values.careerFunctionId || values.careerFunctionId === 0

--- a/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
+++ b/apps/people-app/webapp/src/view/employees/onboarding/singleOnboarding/steps/JobInfo.tsx
@@ -974,7 +974,7 @@ export default function JobInfoStep({ isEditMode }: { isEditMode?: boolean }) {
               ) : (
                 <TextField
                   fullWidth
-                  label="Continuous Service Record"
+                  label="Employee ID (Previous)"
                   value={errorMessage ? "Error" : "No Record"}
                   disabled
                   error={!!errorMessage}


### PR DESCRIPTION
## Summary
- Allow onboarding with a NIC/Passport that already exists **when the work email matches** a prior employee record for that person (rehire) — refreshes their `personal_info` in place and links the new `employee` row to the same `personal_info_id`, instead of blocking. Blocks if there's already an **active** employee under that NIC, or if the NIC matches a different person's email.
- Make **Probation** a fully working, selectable employment type during onboarding. It existed in the DB but previously 500'd if selected (no match arm in employee-ID generation); now shares the Permanent employee-ID sequence, and its Probation End Date derives from the same location-based probation period as Permanent.
- Fix Probation End Date resetting to `null` immediately after a manual date selection (stale `useEffect` dependency was re-triggering the auto-calc on every edit).
- Fix the "Employee ID (Previous)" field showing an inconsistent label ("Continuous Service Record") when no prior record is found for the entered work email.
- Fix `addPersonalInfo` throwing a `TypeCastError` when the `personal_info_audit` trigger is active on `personal_info` — the JDBC driver's generated-keys result comes back nil once an `AFTER` trigger performs its own auto-increment insert; now reads `LAST_INSERT_ID()` explicitly instead of trusting `result.lastInsertId`.
- Show Job Band next to each Designation option in onboarding (`"<Designation> (JB <n>)"`), sorted by Job Band ascending.

## Post-review fixes (round 1 — self-review)
- Block onboarding when the matched NIC already has an **active** employee record, even if the work email matches (previously only checked email match, which allowed creating a second active employee row for someone still employed).
- Removed now-dead `searchEmployeePersonalInfo`/`searchEmployeePersonalInfoQuery`/`SearchEmployeePersonalInfoPayload`, orphaned by the switch to `getPersonalInfoIdByNic`.

## Post-review fixes (round 2 — CodeRabbit + Copilot automated review)
- **Bulk CSV onboarding could generate duplicate employee IDs.** The in-batch sequence cache in `generateBulkEmployeeId` keyed Permanent and Probation rows separately (`companyPrefix:PERMANENT` vs `companyPrefix:PROBATION`) despite both sharing one numeric sequence — a CSV with interleaved Permanent/Probation rows for the same company could produce two employees with the same ID. Fixed by sharing one cache key (`PERMANENT_PROBATION`) between them.
- **Job Band dropdown bugs.** A truthy check hid a real `Job Band 0`, and the sort comparator produced `NaN` when two designations both had no job band (`Infinity - Infinity`). Fixed with explicit null-aware checks for both the label and the sort.
- **Editing an existing employee could wipe their Probation End Date.** Before `employmentTypes` finished loading, `isPermanent`/`isProbationType` both evaluated `false` (empty-array `.find()`), so the auto-calc effect cleared `probationEndDate` before the edit-mode preservation check ever ran. Fixed by no-op'ing the effect until employment types have loaded.
- Two stale code comments corrected (one referencing a since-replaced `result.lastInsertId` reliance, one overstating what the inactive-employment-type guard prevents).
- Reviewed and declined: a suggestion to make `generateEmployeeId`/`addEmployeeQuery` preserve employee IDs across a "probation-to-permanent conversion" — no such conversion path exists in this codebase (`generateEmployeeId` is only called from employee creation, never from the job-info edit endpoint), so this doesn't apply.

## Employee-ID generation: digit-family scoping fix
Root-caused a production incident (`Duplicate entry 'LK500220'` in staging, blocking all Permanent/Probation onboarding): the next-employee-ID query was scoped by the employee's *current* employment type, making it blind to any employee tagged with a type outside that filter (e.g. a legacy `FULL TIME` record) that already occupied a number in the same range.
- Replaced type-filtered scoping with scoping by the ID string's own leading digit (`employee_id LIKE '<prefix><digit>%'`), which can never have this blind spot, and formalizes a digit convention: Permanent/Probation → `1`, Internship → `5`, Consultancy family → `0` (zero-padded, since a plain integer can't have a leading zero).
- Added rollover handling (jump to the next order of magnitude when incrementing would flip the leading digit) and applied the same fix to both single- and bulk-onboarding paths.
- A subsequent whole-branch review caught a critical off-by-one in the Consultancy zero-padding exhaustion check that would have reproduced the exact same class of bug at `CON100000` — fixed and re-verified.
- Removed the now-dead type-filtered query/function this replaces.

## House assignment: automatic, not user-selected
House is no longer a manually-picked dropdown during onboarding — it's derived deterministically from the numeric part of the generated employee ID (`numericPart % 4` → CloudBots/Titans/Legions/Wild Boars), computed server-side right after the ID is resolved, in both single and bulk onboarding, overriding whatever the client sends. Removed the "fewest active employees" suggestion logic (bulk round-robin, `/houses/suggested` endpoint, and their frontend counterparts) this replaces. House remains editable when correcting an existing employee via the edit screen.

## Known, accepted follow-ups (not addressed in this PR)
- The rehire upsert overwrites optional `personal_info` fields (address, personal email/phone, resident number) unconditionally — a blank field in the rehire submission will null out previously-stored data rather than preserving it.
- The "same person" check requires an exact match against a *prior* work email for that NIC; a genuine rehire with a new/changed email will be blocked as a false negative.
- `Dependencies.toml` has an incidental `ballerina/data.jsondata` 1.1.3 → 1.1.4 bump from a local `bal build`, left as-is.
- The NIC/email/active-status checks in `service.bal` run outside the transaction that performs the actual upsert + insert in `addEmployee` — a theoretical check-then-act race under concurrent submissions for the same NIC. Low risk given this is an admin-only, low-concurrency endpoint.
- Open discussion: whether the "NIC exists, active employee" and "NIC exists, email mismatch" cases should return distinct error messages instead of the same generic one (currently deliberate, to avoid signaling which check failed — though less relevant given this endpoint is admin-only).

## Test plan
- [x] `bal build` passes
- [x] `tsc --noEmit` passes
- [x] Verified via direct API calls against local backend: fresh employee creation, rehire flows, Probation onboarding, employee-ID digit-family assignment for Permanent/Probation/Internship/Consultancy (including the rollover boundary), and house auto-assignment (confirmed the server overrides a deliberately-wrong client-supplied `houseId` with the correct formula-derived value)
- [ ] Manual UI verification in browser not performed (no browser automation available in this session) — recommend a quick pass on `/onboarding/single` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)