### PR TITLE
People App - refactor(people-scheduler): align client config with ATS conventions and add step logs

### DIFF
--- a/apps/people-app/people-scheduler/Config.toml.local
+++ b/apps/people-app/people-scheduler/Config.toml.local
@@ -4,14 +4,19 @@ user = ""
 password = ""
 database = ""
 port = 0
+maxOpenConnections = 10
+maxConnectionLifeTime = 180.0
+minIdleConnections = 5
 
 [people_scheduler.email]
-emailServiceEndpoint = ""
 appName = ""
-fromEmailAddress = ""
-leaverNotificationRecipients = [""]
 
-[people_scheduler.email.clientAuthConfig]
+[people_scheduler.email.emailServiceConfig]
+emailServiceEndpoint = ""
+to = [""]
+from = ""
+
+[people_scheduler.email.emailServiceConfig.oauthConfig]
 tokenUrl = ""
 clientId = ""
 clientSecret = ""

--- a/apps/people-app/people-scheduler/functions.bal
+++ b/apps/people-app/people-scheduler/functions.bal
@@ -38,7 +38,7 @@ isolated function runLeaverTransition() returns error? {
         return;
     }
 
-    log:printInfo("Auto-transitioned leavers to Left", count = transitions.length());
+    log:printInfo("Leaver transition step completed", count = transitions.length());
 
     error? notifyResult = email:notifyLeaverAutoTransition(transitions);
     if notifyResult is error {

--- a/apps/people-app/people-scheduler/modules/database/client.bal
+++ b/apps/people-app/people-scheduler/modules/database/client.bal
@@ -14,31 +14,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/sql;
 import ballerinax/mysql;
 import ballerinax/mysql.driver as _;
 
-# Database Client Configuration.
-public type DatabaseConfig record {|
-    # If the MySQL server is secured, the username
-    string user;
-    # The password of the MySQL server for the provided username
-    string password;
-    # The name of the database
-    string database;
-    # Hostname of the MySQL server
-    string host;
-    # Port number of the MySQL server
-    int port;
-    # The `mysql:Options` configurations
-    mysql:Options options?;
-    # The `sql:ConnectionPool` configurations
-    sql:ConnectionPool connectionPool?;
-|};
-
+# People Ops Database Client Configuration.
 configurable DatabaseConfig dbConfig = ?;
 
-function initSchedulerDbClient() returns mysql:Client|error => new (...dbConfig);
-
 # Database Client, shared across all scheduled jobs.
-public final mysql:Client databaseClient = check initSchedulerDbClient();
+public final mysql:Client databaseClient = check new (
+    user = dbConfig.user,
+    password = dbConfig.password,
+    database = dbConfig.database,
+    host = dbConfig.host,
+    port = dbConfig.port,
+    options = {
+        ssl: {
+            mode: mysql:SSL_PREFERRED
+        },
+        connectTimeout: 10
+    },
+    connectionPool = {
+        maxOpenConnections: dbConfig.maxOpenConnections,
+        maxConnectionLifeTime: dbConfig.maxConnectionLifeTime,
+        minIdleConnections: dbConfig.minIdleConnections
+    }
+);

--- a/apps/people-app/people-scheduler/modules/database/functions.bal
+++ b/apps/people-app/people-scheduler/modules/database/functions.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/log;
 import ballerina/sql;
 
 # Check the affected row count after an update operation.
@@ -32,9 +33,13 @@ isolated function checkAffectedCount(int? affectedRowCount) returns error? {
 # + actor - System actor performing the update (e.g. "system-scheduler")
 # + return - The employees that were transitioned (empty if none were due), or an error
 public isolated function transitionExpiredLeavers(string actor) returns LeaverTransition[]|error {
+    log:printInfo("Loading employees due for leaver transition");
+
     stream<LeaverTransition, error?> expiredLeaversStream = databaseClient->query(getExpiredLeaversQuery());
     LeaverTransition[] transitions = check from LeaverTransition transition in expiredLeaversStream
         select transition;
+
+    log:printInfo("Loaded employees due for leaver transition", count = transitions.length());
 
     if transitions.length() == 0 {
         return transitions;
@@ -48,6 +53,8 @@ public isolated function transitionExpiredLeavers(string actor) returns LeaverTr
         check checkAffectedCount(executionResult.affectedRowCount);
         check commit;
     }
+
+    log:printInfo("Marked employees as Left", count = transitions.length());
 
     return transitions;
 }

--- a/apps/people-app/people-scheduler/modules/database/types.bal
+++ b/apps/people-app/people-scheduler/modules/database/types.bal
@@ -16,6 +16,26 @@
 
 import ballerina/sql;
 
+# [Configurable] People Ops database configs.
+type DatabaseConfig record {|
+    # User of the database
+    string user;
+    # Password of the database
+    string password;
+    # Name of the database
+    string database;
+    # Host of the database
+    string host;
+    # Port of the database
+    int port;
+    # Maximum number of open connections
+    int maxOpenConnections;
+    # Maximum lifetime of a connection
+    decimal maxConnectionLifeTime;
+    # Minimum number of open connections
+    int minIdleConnections;
+|};
+
 # Row mapping for an employee whose Marked-leaver period has ended and who should transition to Left.
 public type LeaverTransition record {|
     # External employee ID

--- a/apps/people-app/people-scheduler/modules/email/client.bal
+++ b/apps/people-app/people-scheduler/modules/email/client.bal
@@ -16,15 +16,17 @@
 
 import ballerina/http;
 
-public configurable string emailServiceEndpoint = ?;
-public configurable ClientAuthConfig clientAuthConfig = ?;
-public configurable string appName = ?;
-public configurable string fromEmailAddress = ?;
+configurable EmailServiceConfig emailServiceConfig = ?;
+configurable string appName = ?;
 
 # Email HTTP client, shared across all scheduled jobs.
-public final http:Client emailClient = check new (emailServiceEndpoint, {
+@display {
+    label: "Email Notifications Service",
+    id: "infra/email-notifications-service"
+}
+final http:Client emailClient = check new (emailServiceConfig.emailServiceEndpoint, {
     auth: {
-        ...clientAuthConfig
+        ...emailServiceConfig.oauthConfig
     },
     timeout: 15.0,
     httpVersion: http:HTTP_1_1,

--- a/apps/people-app/people-scheduler/modules/email/leaver_transition_email.bal
+++ b/apps/people-app/people-scheduler/modules/email/leaver_transition_email.bal
@@ -20,8 +20,6 @@ import ballerina/http;
 import ballerina/log;
 import ballerina/time;
 
-configurable string[] leaverNotificationRecipients = ?;
-
 # Send a summary email listing employees auto-transitioned from Marked leaver to Left.
 #
 # + transitions - Employees that were transitioned during this sweep (must be non-empty)
@@ -50,11 +48,14 @@ public isolated function notifyLeaverAutoTransition(database:LeaverTransition[] 
     }
 
     EmailPayload emailPayload = {
-        to: leaverNotificationRecipients,
-        'from: fromEmailAddress,
+        to: emailServiceConfig.to,
+        'from: emailServiceConfig.'from,
         subject: string `Employee Offboarding Alert (${runDate}): ${transitions.length()} employee(s) transitioned to Left`,
         template: boundTemplate
     };
+
+    log:printInfo("Sending leaver auto-transition summary email", count = transitions.length(),
+            recipientCount = emailServiceConfig.to.length());
 
     http:Response|http:ClientError response = emailClient->/send\-email.post(emailPayload);
     if response is http:ClientError {

--- a/apps/people-app/people-scheduler/modules/email/types.bal
+++ b/apps/people-app/people-scheduler/modules/email/types.bal
@@ -15,13 +15,25 @@
 // under the License.
 
 # OAuth2 client auth configurations.
-public type ClientAuthConfig record {|
+type Oauth2Config record {|
     # Token URL
     string tokenUrl;
     # Client ID
     string clientId;
     # Client Secret
     string clientSecret;
+|};
+
+# [Configurable] Email notification service configs.
+type EmailServiceConfig record {|
+    # Email Service Endpoint
+    string emailServiceEndpoint;
+    # Auth Configurations
+    Oauth2Config oauthConfig;
+    # Recipient email(s) as string array
+    string[] to;
+    # Sender email
+    string 'from;
 |};
 
 # Payload of the email alerting service.


### PR DESCRIPTION
## Purpose

Follow-up to #317. The People Scheduler's database and email client configuration did not follow the conventions used elsewhere (ATS backend, People App backend): config record types were declared inside `client.bal`, exported as `public`, and the email module exposed four loose top-level `configurable` values.

This aligns the scheduler with the ATS backend pattern and adds per-step info logging to the leaver sweep.

## Changes

### Client configuration

- **`DatabaseConfig`** moved out of `modules/database/client.bal` into `types.bal` as a module-private type, and reshaped to carry pool sizes directly (`maxOpenConnections`, `maxConnectionLifeTime`, `minIdleConnections`) instead of pass-through `mysql:Options` / `sql:ConnectionPool` records. SSL mode (`SSL_PREFERRED`) and `connectTimeout` are now fixed in `client.bal` rather than being configurable, matching ATS.
- **`ClientAuthConfig` renamed to `Oauth2Config`** — the name used by both the ATS backend and the People App backend.
- **`EmailServiceConfig`** introduced to group the four previously loose `public configurable` values (`emailServiceEndpoint`, `clientAuthConfig`, `fromEmailAddress`, and `leaverNotificationRecipients` — the last of which was declared in a separate file) into one record holding `emailServiceEndpoint`, `oauthConfig`, `to`, and `from`.
- Config record types are **no longer exported** (`public` dropped) — nothing outside the owning module reads them.
- Added the Choreo **`@display`** annotation to the email client, matching the ATS email client.
- `Config.toml.local` restructured to the new nested shape.

### Step logging

The load and the update happened inside a single function and neither was logged, so the first signal of a sweep was the post-transition count — if the query succeeded but the `UPDATE` failed, there was no log showing the load had worked. Added info logs for each step:

- `Loading employees due for leaver transition` — before the query
- `Loaded employees due for leaver transition` (with `count`) — after the stream collects, placed before the early return so the zero case is visible
- `Marked employees as Left` (with `count`) — after `commit`, so it only appears once the transaction lands
- `Sending leaver auto-transition summary email` (with `count`, `recipientCount`) — before the POST

Reworded the job-level `Auto-transitioned leavers to Left` to `Leaver transition step completed`, as it otherwise duplicated the new database-layer log with the same count.

Employee IDs are deliberately kept out of the logs — the summary email already itemises who was transitioned.

## Note for reviewers

This changes the **deployment config shape**, so the Choreo configuration for the scheduler must be updated to the new nested structure (see `Config.toml.local`). It can no longer be copied from the People App backend's config, which still nests `connectionPool` / `options.ssl` as configurable values.

## Testing

- `bal build` — compiles clean
- `bal run` against a local database — verified both configurable records bind correctly (including the `'from` → `from` TOML key mapping) and confirmed the new load-step logs emit:
  ```
  message="Leaver auto-transition sweep started"
  message="Loading employees due for leaver transition"
  message="Loaded employees due for leaver transition" count=0
  message="Leaver auto-transition sweep completed — no employees due for transition"
  ```
- The non-zero path logs (`Marked employees as Left`, the sending log) compile but were not observed firing, as the local database had no due leavers remaining after an earlier run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved database connection handling with configurable timeouts and connection-pool settings.
  * Consolidated email service configuration, including sender, recipients, endpoint, and OAuth settings.
  * Updated email notifications to use the revised configuration consistently.

* **Bug Fixes**
  * Clarified leaver transition status messaging to accurately reflect completed transitions.

* **Observability**
  * Added informational logs for loaded leavers, completed transitions, transition counts, and notification recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->