### PR TITLE
People App - feat(people-scheduler): present leaver summary email as a sorted table with readable dates

### DIFF
--- a/apps/people-app/people-scheduler/modules/email/leaver_transition_email.bal
+++ b/apps/people-app/people-scheduler/modules/email/leaver_transition_email.bal
@@ -25,10 +25,7 @@ import ballerina/time;
 # + transitions - Employees that were transitioned during this sweep (must be non-empty)
 # + return - Error if the email notification fails to send
 public isolated function notifyLeaverAutoTransition(database:LeaverTransition[] transitions) returns error? {
-    string employeeListHtml = string:'join("",
-    ...from database:LeaverTransition t in transitions
-       select string `<li>${htmlEscape(t.firstName)} ${htmlEscape(t.lastName)} (${htmlEscape(t.employeeId)})
-            &mdash; ${htmlEscape(t.workEmail)} &mdash; final day: ${htmlEscape(t.finalDayOfEmployment)}</li>`);
+    string employeeListHtml = buildTransitionRows(transitions);
 
     string runDate = time:utcToString(time:utcNow()).substring(0, 10);
 
@@ -70,4 +67,46 @@ public isolated function notifyLeaverAutoTransition(database:LeaverTransition[] 
         return error(customError);
     }
     log:printInfo(string `Leaver auto-transition summary email sent on ${runDate} for ${transitions.length()} leaver(s)`);
+}
+
+# Build the `<tbody>` rows for the transitioned-employees table, latest final day of employment
+# first and tie-broken by employee ID so the listing is stable across runs (the underlying query
+# applies no ordering of its own). Same-date employees are grouped under a date band.
+#
+# + transitions - Employees that were transitioned during this sweep
+# + return - HTML table rows, safe to inject into the template
+isolated function buildTransitionRows(database:LeaverTransition[] transitions) returns string {
+    database:LeaverTransition[] sorted = from database:LeaverTransition t in transitions
+        order by t.finalDayOfEmployment descending, t.employeeId ascending
+        select t;
+
+    // Count per final day up front so each date band can state its own total.
+    map<int> countsByDate = {};
+    foreach database:LeaverTransition t in sorted {
+        countsByDate[t.finalDayOfEmployment] = (countsByDate[t.finalDayOfEmployment] ?: 0) + 1;
+    }
+
+    string cellBase = "padding:10px 12px; border-bottom:1px solid #eef1f4; vertical-align:top;";
+    string rows = "";
+    string currentDate = "";
+
+    foreach database:LeaverTransition t in sorted {
+        if t.finalDayOfEmployment != currentDate {
+            currentDate = t.finalDayOfEmployment;
+            int dateCount = countsByDate[currentDate] ?: 0;
+            rows += string `<tr><td colspan="4" style="padding:9px 16px; background-color:#eef2f6;` +
+                string ` border-top:1px solid #d8dfe6; border-bottom:1px solid #d8dfe6; font-size:13px;` +
+                string ` font-weight:bold; color:#33455c;">` +
+                string `${htmlEscape(currentDate)} <span style="font-weight:normal; color:#6b7a8c;">` +
+                string `(${dateCount})</span></td></tr>`;
+        }
+        rows += string `<tr>` +
+            string `<td style="${cellBase} padding-left:16px; white-space:nowrap;">${htmlEscape(t.employeeId)}</td>` +
+            string `<td style="${cellBase}">${htmlEscape(t.firstName)} ${htmlEscape(t.lastName)}</td>` +
+            string `<td style="${cellBase}">${htmlEscape(t.workEmail)}</td>` +
+            string `<td align="right" style="${cellBase} padding-right:16px; white-space:nowrap;` +
+            string ` color:#7a8899;">${htmlEscape(t.finalDayOfEmployment)}</td>` +
+            string `</tr>`;
+    }
+    return rows;
 }

--- a/apps/people-app/people-scheduler/modules/email/leaver_transition_email.bal
+++ b/apps/people-app/people-scheduler/modules/email/leaver_transition_email.bal
@@ -97,7 +97,7 @@ isolated function buildTransitionRows(database:LeaverTransition[] transitions) r
             rows += string `<tr><td colspan="4" style="padding:9px 16px; background-color:#eef2f6;` +
                 string ` border-top:1px solid #d8dfe6; border-bottom:1px solid #d8dfe6; font-size:13px;` +
                 string ` font-weight:bold; color:#33455c;">` +
-                string `${htmlEscape(currentDate)} <span style="font-weight:normal; color:#6b7a8c;">` +
+                string `${htmlEscape(formatDisplayDate(currentDate))} <span style="font-weight:normal; color:#6b7a8c;">` +
                 string `(${dateCount})</span></td></tr>`;
         }
         rows += string `<tr>` +
@@ -105,7 +105,7 @@ isolated function buildTransitionRows(database:LeaverTransition[] transitions) r
             string `<td style="${cellBase}">${htmlEscape(t.firstName)} ${htmlEscape(t.lastName)}</td>` +
             string `<td style="${cellBase}">${htmlEscape(t.workEmail)}</td>` +
             string `<td align="right" style="${cellBase} padding-right:16px; white-space:nowrap;` +
-            string ` color:#7a8899;">${htmlEscape(t.finalDayOfEmployment)}</td>` +
+            string ` color:#7a8899;">${htmlEscape(formatDisplayDate(t.finalDayOfEmployment))}</td>` +
             string `</tr>`;
     }
     return rows;

--- a/apps/people-app/people-scheduler/modules/email/templates.bal
+++ b/apps/people-app/people-scheduler/modules/email/templates.bal
@@ -161,23 +161,79 @@ public final string leaverAutoTransitionSummaryTemplate = string `
                         border:1px solid #e0e0e0;
                         border-radius:4px;
                         margin-top:8px;
+                        font-family:'Roboto', Helvetica, sans-serif;
+                        font-size:13px;
+                        color:#465868;
                       "
                     >
-                      <tbody>
+                      <thead>
                         <tr>
-                          <td
+                          <th
+                            align="left"
                             style="
-                              padding:12px 16px;
-                              font-family:'Roboto', Helvetica, sans-serif;
-                              font-size:14px;
-                              color:#465868;
+                              padding:10px 16px;
+                              background-color:#f7f9fb;
+                              border-bottom:1px solid #e0e0e0;
+                              font-size:11px;
+                              font-weight:bold;
+                              letter-spacing:0.6px;
+                              text-transform:uppercase;
+                              color:#7a8899;
+                              white-space:nowrap;
                             "
                           >
-                            <ul style="margin:0; padding-left:20px;">
-                              <!-- [EMPLOYEE_LIST] -->
-                            </ul>
-                          </td>
+                            ID
+                          </th>
+                          <th
+                            align="left"
+                            style="
+                              padding:10px 12px;
+                              background-color:#f7f9fb;
+                              border-bottom:1px solid #e0e0e0;
+                              font-size:11px;
+                              font-weight:bold;
+                              letter-spacing:0.6px;
+                              text-transform:uppercase;
+                              color:#7a8899;
+                            "
+                          >
+                            Employee
+                          </th>
+                          <th
+                            align="left"
+                            style="
+                              padding:10px 12px;
+                              background-color:#f7f9fb;
+                              border-bottom:1px solid #e0e0e0;
+                              font-size:11px;
+                              font-weight:bold;
+                              letter-spacing:0.6px;
+                              text-transform:uppercase;
+                              color:#7a8899;
+                            "
+                          >
+                            Work email
+                          </th>
+                          <th
+                            align="right"
+                            style="
+                              padding:10px 16px;
+                              background-color:#f7f9fb;
+                              border-bottom:1px solid #e0e0e0;
+                              font-size:11px;
+                              font-weight:bold;
+                              letter-spacing:0.6px;
+                              text-transform:uppercase;
+                              color:#7a8899;
+                              white-space:nowrap;
+                            "
+                          >
+                            Final day
+                          </th>
                         </tr>
+                      </thead>
+                      <tbody>
+                        <!-- [EMPLOYEE_LIST] -->
                       </tbody>
                     </table>
 

--- a/apps/people-app/people-scheduler/modules/email/util.bal
+++ b/apps/people-app/people-scheduler/modules/email/util.bal
@@ -32,6 +32,41 @@ public isolated function htmlEscape(string str) returns string {
     return escaped;
 }
 
+# Month names indexed by month number (1-12).
+final readonly & string[] MONTH_NAMES = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+];
+
+# Format an ISO `yyyy-MM-dd` date as `MMMM dd, yyyy` (e.g. "2026-08-07" -> "August 07, 2026")
+# for display in emails. Returns the input unchanged if it is not in the expected form, so a
+# malformed value degrades to the raw date rather than failing the notification.
+#
+# + isoDate - Date string in `yyyy-MM-dd` form
+# + return - Human-readable date, or the input unchanged if it cannot be parsed
+public isolated function formatDisplayDate(string isoDate) returns string {
+    string[] parts = re `-`.split(isoDate);
+    if parts.length() != 3 {
+        return isoDate;
+    }
+    int|error year = int:fromString(parts[0]);
+    int|error month = int:fromString(parts[1]);
+    if year is error || month is error || month < 1 || month > 12 {
+        return isoDate;
+    }
+    return string `${MONTH_NAMES[month - 1]} ${parts[2]}, ${year}`;
+}
+
 # Bind values to the email template and encode.
 #
 # + content - Email content


### PR DESCRIPTION
## Purpose

Follow-up to #321. The leaver auto-transition summary email listed employees as `<li>` items with every field run together on one line, in whatever order the query happened to return them — the underlying query applies no `ORDER BY`, so the listing was effectively arbitrary and could shuffle between runs.

This makes the listing scannable and deterministic.

## Changes

### Ordering

- Sort by final day of employment, **latest first**, tie-broken by employee ID so the listing is stable across runs. On the current staging data 13 of 19 employees share one final day, so without the tiebreak that block would still shuffle.
- Sorting happens while building the rows, so the caller's `transitions` array is left untouched — `notifyLeaverAutoTransition` stays free of side effects on its argument.
- The database query is deliberately **not** modified; ordering is a presentation concern here.

### Table layout

- Replaced the bulleted list with a four-column table: **ID · Employee · Work email · Final day**.
- Same-day employees are grouped under a date band showing the date and how many fall on it (e.g. `July 31, 2026 (13)`).

### Readable dates

- Final day renders as `MMMM dd, yyyy` (e.g. `August 07, 2026`) instead of the raw `yyyy-MM-dd`.
- `final_day_of_employment` is read as a plain string rather than a date type, so `formatDisplayDate()` parses the parts itself and returns the input unchanged when it is not in the expected form — a malformed value degrades to the raw date instead of failing the notification.
- Sorting and the per-date grouping still key on the **raw ISO string**; formatting is applied at render time only. Formatting before sorting would order by month name alphabetically (`August` before `July`) and silently invert the intended order.

## Implementation notes

All markup is inline-styled table HTML — no flexbox, grid, or CSS classes on rows — so it renders in Outlook and Gmail, matching how the rest of the template is already built. Every interpolated value still passes through `htmlEscape`; the `EMPLOYEE_LIST` placeholder remains the one value `bindKeyValues` injects unescaped, and it is assembled entirely from escaped parts.

## Testing

- `bal build` — compiles clean.
- `formatDisplayDate()` exercised standalone across valid and malformed inputs:
  ```
  2026-08-07 -> August 07, 2026     2026-13-01 -> 2026-13-01   (bad month)
  2026-01-01 -> January 01, 2026    2026-00-05 -> 2026-00-05   (bad month)
  2026-12-25 -> December 25, 2026   2026-08    -> 2026-08      (2 parts)
  2026-8-7   -> August 7, 2026      abcd-08-07 -> abcd-08-07   (bad year)
  ```
- Rendered the full template against 19 real staging records and confirmed the band sequence is chronological (`August 07 → August 06 → August 02 → August 01 → July 31`), all placeholders bind, and no raw ISO dates remain in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated employee transition emails with a clearer, styled table showing employee ID, name, work email, and final day.
  * Grouped transitioning employees by final employment date, including per-date counts.
  * Sorted entries consistently by final day and employee ID.
  * Added readable date formatting with full month names while preserving invalid date values unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->