### PR TITLE
fix(leave-app): fix Notify people search and exclude left employees

### DIFF
--- a/apps/leave-app/webapp/src/view/GeneralLeave/component/NotifyPeople.tsx
+++ b/apps/leave-app/webapp/src/view/GeneralLeave/component/NotifyPeople.tsx
@@ -20,6 +20,7 @@ import {
   Box,
   Chip,
   CircularProgress,
+  createFilterOptions,
   InputAdornment,
   Stack,
   TextField,
@@ -32,15 +33,23 @@ import { useEffect, useState } from "react";
 import { selectAppConfig } from "@root/src/slices/configSlice/config";
 import { selectEmployeeState, selectEmployees } from "@root/src/slices/employeeSlice/employee";
 import { useAppSelector } from "@root/src/slices/store";
-import { CachedMail, State } from "@root/src/types/types";
+import { CachedMail, EmployeeStatus, State } from "@root/src/types/types";
 
 interface EmployeeOption {
-  label: string;
   displayName: string;
   email: string;
   thumbnail: string | null;
   isFixed?: boolean;
 }
+
+const getOptionLabel = (option: EmployeeOption) =>
+  option.displayName ? `${option.displayName} (${option.email})` : option.email;
+
+// Cap rendered matches so typing doesn't mount hundreds of Autocomplete list items at once.
+const filterOptions = createFilterOptions<EmployeeOption>({
+  stringify: getOptionLabel,
+  limit: 50,
+});
 
 interface NotifyPeopleProps {
   selectedEmails: string[];
@@ -68,7 +77,6 @@ export default function NotifyPeople({
     const defaultMails: CachedMail = appConfig.cachedEmails;
 
     const mandatoryOptions = defaultMails.mandatoryMails.map((mail) => ({
-      label: mail.email,
       displayName: mail.email,
       email: mail.email,
       thumbnail: mail.thumbnail || null,
@@ -78,7 +86,6 @@ export default function NotifyPeople({
     const optionalOptions = defaultMails.optionalMails
       .filter((mail) => !defaultMails.mandatoryMails.find((m) => m.email === mail.email))
       .map((mail) => ({
-        label: mail.email,
         displayName: mail.email,
         email: mail.email,
         thumbnail: mail.thumbnail || null,
@@ -96,13 +103,14 @@ export default function NotifyPeople({
 
   useEffect(() => {
     if (employees.length > 0) {
-      const employeeOptionsFromApi = employees.map((employee) => ({
-        label: `${employee.firstName} ${employee.lastName} (${employee.workEmail})`,
-        displayName: `${employee.firstName} ${employee.lastName}`.trim(),
-        email: employee.workEmail,
-        thumbnail: employee.employeeThumbnail,
-        isFixed: fixedEmails.includes(employee.workEmail),
-      }));
+      const employeeOptionsFromApi = employees
+        .filter((employee) => employee.employeeStatus !== EmployeeStatus.LEFT)
+        .map((employee) => ({
+          displayName: `${employee.firstName} ${employee.lastName}`.trim(),
+          email: employee.workEmail,
+          thumbnail: employee.employeeThumbnail,
+          isFixed: fixedEmails.includes(employee.workEmail),
+        }));
 
       setEmployeeOptions((prev) => {
         const apiByEmail = new Map(employeeOptionsFromApi.map((o) => [o.email, o]));
@@ -154,7 +162,8 @@ export default function NotifyPeople({
           ];
           onEmailsChange(newEmails);
         }}
-        getOptionLabel={(option) => option.label}
+        getOptionLabel={getOptionLabel}
+        filterOptions={filterOptions}
         isOptionEqualToValue={(option, value) => option.email === value.email}
         renderOption={(props, option) => (
           <li


### PR DESCRIPTION
## Summary
- Fixed search-by-name failing for pre-cached mandatory/optional notify recipients (e.g. HR/manager) — their searchable label never picked up the real name once loaded from the employee API, only the display name/avatar shown to the user was refreshed.
- Capped rendered Autocomplete matches to 50 (`filterOptions` with `limit`) so broad/short search terms don't mount hundreds of option rows at once, which was causing noticeable input lag.
- Excluded employees with status `Left` from the Apply tab's "Notify people" dropdown, since they don't need to be notified about a leave request. The Report tab's employee list/filtering is untouched, so left employees remain visible there for historical reporting.

## Test plan
- [x] Open the Apply tab (General Leave), open the "Notify people" search, and confirm typing a colleague's name (including a default mandatory/optional recipient) filters correctly and responsively.
- [x] Confirm employees with status "Left" no longer appear in the Notify people dropdown.
- [ ] Confirm the Report tab still shows/filters "Left" employees as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Excluded departed employees from people-selection options.
  - Improved autocomplete labels by consistently using employee display names.
  - Limited autocomplete results to the first 50 matches for clearer, faster selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->