### PR TITLE
People App - Employee history timeline

### DIFF
--- a/apps/people-app/CLAUDE.md
+++ b/apps/people-app/CLAUDE.md
@@ -60,12 +60,13 @@ Runtime config injected via `window.config`. Required keys: `CLIENT_ID`, `SIGN_I
 ### Backend
 
 - Ballerina 2201.12.7, organized as package `wso2_open_operations/people`
-- Six modules:
+- Seven modules:
   - **`authorization`** — `JwtInterceptor` reads the `x-jwt-assertion` header, decodes the JWT, validates group membership, and stores `CustomJwtPayload` in the request context. Roles configured via `Config.toml`: `EMPLOYEE_ROLE`, `ADMIN_ROLE`, and `SERVICE_DESK_ROLE`.
   - **`database`** — MySQL client, all DB queries (`db_queries.bal`), DB functions (`db_functions.bal`), types, enums, and utils.
   - **`email`** — Email notification client; sends alerts via an external email service for onboarding events (e.g., failed Asgardeo group assignments).
   - **`qr`** — QR code generation for employees (`qr.bal`, `clients.bal`, `types.bal`).
   - **`scim`** — Asgardeo SCIM client for user and group management in the internal org; used during employee onboarding and bulk provisioning.
+  - **`promotion`** — Read-only client for the separate HRIS database (`promotionDbConfig`), supplying approved promotion history to the employee history timeline. Kept apart from `database` because it is a second datasource: its own client, config and types, so the dependency can be replaced or removed without touching the primary database module.
   - **`wso2_coin`** — Car park reservation + O2C payment integration. Bundles the blockchain transaction client (`transaction.bal`, `clients.bal`), Google Sheets parking-record sync (`parkingSheet.bal`), shared types/constants, and admin scripts. Exposes config values like `masterWalletAddress`, `reservationWindowStartHour/EndHour`, and `pendingReservationExpiryMinutes` consumed directly from `service.bal`. The microapp's parking booking flow (`/services/parking/*`) is the frontend surface for this module.
 - Every resource function in `service.bal` extracts `userInfo` from `ctx` and checks role permissions before executing business logic.
 - Four privilege levels — `EMPLOYEE_PRIVILEGE`, `LEAD_PRIVILEGE`, `SERVICE_DESK_PRIVILEGE`, and `ADMIN_PRIVILEGE` — are returned to the frontend in `/user-info`.

--- a/apps/people-app/backend/Config.toml.local
+++ b/apps/people-app/backend/Config.toml.local
@@ -14,16 +14,14 @@ EXTERNAL_USER_ROLES = [];
     maxOpenConnections = 
     maxConnectionLifeTime = 
     minIdleConnections= 
-    [people.database.dbConfig.options]
-    connectTimeout = 
-    [people.database.dbConfig.options.ssl]
-    mode = "PREFERRED"
+
 
 [people.promotion.promotionDbConfig]
     host = ""
     user = ""
     password = ""
     database = ""
+    port =
     [people.promotion.promotionDbConfig.connectionPool]
     maxOpenConnections =
     maxConnectionLifeTime =

--- a/apps/people-app/backend/Config.toml.local
+++ b/apps/people-app/backend/Config.toml.local
@@ -22,6 +22,10 @@ EXTERNAL_USER_ROLES = [];
     password = ""
     database = ""
     port =
+    # Keep maxConnectionLifeTime below the HRIS server's wait_timeout (300s at the
+    # time of writing) and minIdleConnections at 0. The pool must retire a
+    # connection before the server closes it, or a query after an idle period
+    # fails with "No operations allowed after connection closed" (SQL state 08003).
     [people.promotion.promotionDbConfig.connectionPool]
     maxOpenConnections =
     maxConnectionLifeTime =

--- a/apps/people-app/backend/Config.toml.local
+++ b/apps/people-app/backend/Config.toml.local
@@ -19,6 +19,16 @@ EXTERNAL_USER_ROLES = [];
     [people.database.dbConfig.options.ssl]
     mode = "PREFERRED"
 
+[people.promotion.promotionDbConfig]
+    host = ""
+    user = ""
+    password = ""
+    database = ""
+    [people.promotion.promotionDbConfig.connectionPool]
+    maxOpenConnections =
+    maxConnectionLifeTime =
+    minIdleConnections =
+
 [people.wso2_coin]
     masterWalletAddress = ""
     reservationWindowStartHour = 

--- a/apps/people-app/backend/Config.toml.local
+++ b/apps/people-app/backend/Config.toml.local
@@ -11,10 +11,13 @@ EXTERNAL_USER_ROLES = [];
     database = ""
     port = 
     [people.database.dbConfig.connectionPool]
-    maxOpenConnections = 
-    maxConnectionLifeTime = 
-    minIdleConnections= 
-
+    maxOpenConnections =
+    maxConnectionLifeTime =
+    minIdleConnections=
+    [people.database.dbConfig.options]
+    connectTimeout =
+    [people.database.dbConfig.options.ssl]
+    mode = "PREFERRED"
 
 [people.promotion.promotionDbConfig]
     host = ""
@@ -30,6 +33,10 @@ EXTERNAL_USER_ROLES = [];
     maxOpenConnections =
     maxConnectionLifeTime =
     minIdleConnections =
+    [people.promotion.promotionDbConfig.options]
+    connectTimeout =
+    [people.promotion.promotionDbConfig.options.ssl]
+    mode = "PREFERRED"
 
 [people.wso2_coin]
     masterWalletAddress = ""

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -1513,3 +1513,46 @@ public isolated function hasActiveEmployeesInBUTeamSubTeamUnitMapping(int id) re
             countActiveEmployeesInBUTeamSubTeamUnitMappingQuery(id));
     return result.count > 0;
 }
+
+# Fetch every employment period for the person behind an employee ID.
+#
+# + employeeId - Employee ID of any one of the person's employment records
+# + return - Employment periods for the person, newest first
+public isolated function getEmploymentPeriods(string employeeId) returns EmploymentPeriod[]|error {
+    stream<EmploymentPeriod, error?> periodStream = databaseClient->query(getEmploymentPeriodsQuery(employeeId));
+    return from EmploymentPeriod period in periodStream
+        select period;
+}
+
+# Fetch raw audit snapshots across all audit tables for a person's employee rows.
+#
+# Each source table is queried and ordered independently, then merged and re-sorted by action_on
+# ascending across the combined set, since Task 3 diffs consecutive rows and depends on one
+# globally-ordered timeline rather than three independently-ordered ones.
+#
+# + employeePkIds - Employee table primary keys belonging to the person
+# + return - Audit snapshots from employee_audit, personal_info_audit, and
+# employee_additional_managers_audit, ordered by action_on ascending across all three
+public isolated function getAuditSnapshots(int[] employeePkIds) returns AuditSnapshot[]|error {
+    stream<AuditSnapshot, error?> employeeAuditStream =
+        databaseClient->query(getEmployeeAuditSnapshotsQuery(employeePkIds));
+    AuditSnapshot[] employeeAuditSnapshots = check from AuditSnapshot snapshot in employeeAuditStream
+        select snapshot;
+
+    stream<AuditSnapshot, error?> personalInfoAuditStream =
+        databaseClient->query(getPersonalInfoAuditSnapshotsQuery(employeePkIds));
+    AuditSnapshot[] personalInfoAuditSnapshots = check from AuditSnapshot snapshot in personalInfoAuditStream
+        select snapshot;
+
+    stream<AuditSnapshot, error?> additionalManagersAuditStream =
+        databaseClient->query(getEmployeeAdditionalManagersAuditSnapshotsQuery(employeePkIds));
+    AuditSnapshot[] additionalManagersAuditSnapshots =
+        check from AuditSnapshot snapshot in additionalManagersAuditStream
+        select snapshot;
+
+    AuditSnapshot[] allSnapshots =
+        [...employeeAuditSnapshots, ...personalInfoAuditSnapshots, ...additionalManagersAuditSnapshots];
+    return from AuditSnapshot snapshot in allSnapshots
+        order by snapshot.actionOn ascending
+        select snapshot;
+}

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -1599,3 +1599,18 @@ public isolated function getHistoryLookupNames() returns map<map<string>>|error 
 
     return lookup;
 }
+
+# Whether an employee ID names the person's current (most recent) employment.
+#
+# + employeeId - Employee ID to test
+# + return - True when this is the person's latest employment row, or an error
+public isolated function isCurrentEmployment(string employeeId) returns boolean|error {
+    int|error result = databaseClient->queryRow(isCurrentEmploymentQuery(employeeId));
+    if result is sql:NoRowsError {
+        return false;
+    }
+    if result is error {
+        return result;
+    }
+    return true;
+}

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -1514,6 +1514,28 @@ public isolated function hasActiveEmployeesInBUTeamSubTeamUnitMapping(int id) re
     return result.count > 0;
 }
 
+# Resolve the person behind a work email to their personal_info ID.
+#
+# Callers authorizing "may this user see this record" must compare people, not employee IDs. A
+# rehired person holds several employee IDs against one personal_info row, so comparing employee
+# IDs would deny them access to their own earlier employment.
+#
+# + workEmail - Work email of the person
+# + return - personal_info ID, nil if no matching employee record, or error
+public isolated function getPersonalInfoIdByWorkEmail(string workEmail) returns int?|error {
+    int|error result = databaseClient->queryRow(getPersonalInfoIdByWorkEmailQuery(workEmail));
+    return result is sql:NoRowsError ? () : result;
+}
+
+# Resolve the person behind an employee ID to their personal_info ID.
+#
+# + employeeId - Employee ID of any one of the person's employment records
+# + return - personal_info ID, nil if no matching employee record, or error
+public isolated function getPersonalInfoIdByEmployeeId(string employeeId) returns int?|error {
+    int|error result = databaseClient->queryRow(getPersonalInfoIdByEmployeeIdQuery(employeeId));
+    return result is sql:NoRowsError ? () : result;
+}
+
 # Fetch every employment period for the person behind an employee ID.
 #
 # + employeeId - Employee ID of any one of the person's employment records

--- a/apps/people-app/backend/modules/database/db_functions.bal
+++ b/apps/people-app/backend/modules/database/db_functions.bal
@@ -1578,3 +1578,24 @@ public isolated function getAuditSnapshots(int[] employeePkIds) returns AuditSna
         order by snapshot.actionOn ascending
         select snapshot;
 }
+
+# Build a lookup of audit field -> id -> human-readable name.
+#
+# History events carry raw foreign keys from the audit snapshots. Rendering "87" tells a
+# reader nothing, so ids are resolved to names before the response is built.
+#
+# + return - Nested map keyed by field then by id, or an error
+public isolated function getHistoryLookupNames() returns map<map<string>>|error {
+    stream<HistoryLookupName, error?> resultStream =
+        databaseClient->query(getHistoryLookupNamesQuery());
+
+    map<map<string>> lookup = {};
+    check from HistoryLookupName row in resultStream
+        do {
+            map<string> byId = lookup.hasKey(row.'field) ? lookup.get(row.'field) : {};
+            byId[row.id.toString()] = row.name;
+            lookup[row.'field] = byId;
+        };
+
+    return lookup;
+}

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2564,14 +2564,28 @@ isolated function getPersonalInfoAuditSnapshotsQuery(int[] employeePkIds) return
 # query per lookup table. `designation` names its column `designation`; every other
 # lookup table uses `name`.
 #
+# Every string is given an explicit COLLATE. The lookup tables do not agree among
+# themselves — `house.name` is utf8mb4_unicode_ci while the rest are utf8mb4_0900_ai_ci —
+# and the literals would otherwise take the connection default, so a bare UNION fails with
+# "Illegal mix of collations" (MySQL 1271).
+#
 # + return - Parameterized query returning (field, id, name) rows
 isolated function getHistoryLookupNamesQuery() returns sql:ParameterizedQuery =>
-    `SELECT 'business_unit_id' AS field, id, name FROM business_unit
-     UNION ALL SELECT 'team_id', id, name FROM team
-     UNION ALL SELECT 'sub_team_id', id, name FROM sub_team
-     UNION ALL SELECT 'unit_id', id, name FROM unit
-     UNION ALL SELECT 'designation_id', id, designation FROM designation
-     UNION ALL SELECT 'employment_type_id', id, name FROM employment_type
-     UNION ALL SELECT 'company_id', id, name FROM company
-     UNION ALL SELECT 'office_id', id, name FROM office
-     UNION ALL SELECT 'house_id', id, name FROM house`;
+    `SELECT 'business_unit_id' COLLATE utf8mb4_general_ci AS field,
+            id, name COLLATE utf8mb4_general_ci AS name FROM business_unit
+     UNION ALL SELECT 'team_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM team
+     UNION ALL SELECT 'sub_team_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM sub_team
+     UNION ALL SELECT 'unit_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM unit
+     UNION ALL SELECT 'designation_id' COLLATE utf8mb4_general_ci,
+            id, designation COLLATE utf8mb4_general_ci FROM designation
+     UNION ALL SELECT 'employment_type_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM employment_type
+     UNION ALL SELECT 'company_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM company
+     UNION ALL SELECT 'office_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM office
+     UNION ALL SELECT 'house_id' COLLATE utf8mb4_general_ci,
+            id, name COLLATE utf8mb4_general_ci FROM house`;

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2446,6 +2446,25 @@ isolated function deleteEmployeeEmergencyContactsAuditQuery(int personalInfoId) 
 isolated function deletePersonalInfoAuditQuery(int personalInfoId) returns sql:ParameterizedQuery =>
     `DELETE FROM personal_info_audit WHERE personal_info_pk_id = ${personalInfoId};`;
 
+# Resolve the person behind a work email.
+#
+# A person may hold several employee rows over time (a rehire issues a new employee ID while
+# reusing the same personal_info row), so this deliberately returns the personal_info_id rather
+# than an employee ID. LIMIT 1 is safe because every employee row for one person points at the
+# same personal_info_id, and a work email belongs to exactly one employee row.
+#
+# + workEmail - Work email of the person
+# + return - Parameterized query returning the person's personal_info_id
+isolated function getPersonalInfoIdByWorkEmailQuery(string workEmail) returns sql:ParameterizedQuery =>
+    `SELECT personal_info_id FROM employee WHERE work_email = ${workEmail} LIMIT 1;`;
+
+# Resolve the person behind an employee ID.
+#
+# + employeeId - Employee ID of any one of the person's employment records
+# + return - Parameterized query returning the person's personal_info_id
+isolated function getPersonalInfoIdByEmployeeIdQuery(string employeeId) returns sql:ParameterizedQuery =>
+    `SELECT personal_info_id FROM employee WHERE employee_id = ${employeeId} LIMIT 1;`;
+
 # All employment periods for the person behind an employee ID.
 #
 # + employeeId - Employee ID of any one of the person's employment records

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2632,3 +2632,47 @@ isolated function getHistoryLookupNamesQuery() returns sql:ParameterizedQuery =>
             id, name COLLATE utf8mb4_general_ci FROM office
      UNION ALL SELECT 'house_id' COLLATE utf8mb4_general_ci,
             id, name COLLATE utf8mb4_general_ci FROM house`;
+
+# Whether an employee ID names the person's current (most recent) employment.
+#
+# `manager_email` is never cleared when an employment ends, so an old row keeps naming a
+# former manager forever. Any check built on that column therefore has to be paired with a
+# currency test, or a former lead retains access to a person they no longer manage.
+#
+# + employeeId - Employee ID to test
+# + return - Parameterized query returning 1 when this is the person's latest employment
+isolated function isCurrentEmploymentQuery(string employeeId) returns sql:ParameterizedQuery =>
+    `SELECT 1 FROM employee target
+     WHERE target.employee_id = ${employeeId}
+        AND target.id = (
+            -- Resolved through the same chain the history itself walks, not through
+            -- personal_info_id. A person's employments can hold different personal_info rows
+            -- (one NIC recorded several ways), in which case every row would look "latest"
+            -- within its own group of one and the check would pass for all of them.
+            WITH RECURSIVE anchor AS (
+                SELECT id, personal_info_id, continuous_service_record
+                FROM employee WHERE employee_id = ${employeeId}
+            ),
+            earlier AS (
+                SELECT id, continuous_service_record FROM anchor
+                UNION
+                SELECT e2.id, e2.continuous_service_record
+                FROM employee e2 JOIN earlier ON e2.id = earlier.continuous_service_record
+            ),
+            later AS (
+                SELECT id FROM anchor
+                UNION
+                SELECT e3.id FROM employee e3 JOIN later ON e3.continuous_service_record = later.id
+            ),
+            whole_person AS (
+                SELECT id FROM earlier
+                UNION SELECT id FROM later
+                UNION SELECT e4.id FROM employee e4
+                    JOIN anchor ON e4.personal_info_id = anchor.personal_info_id
+            )
+            SELECT latest.id FROM employee latest
+            JOIN whole_person ON whole_person.id = latest.id
+            ORDER BY latest.start_date DESC, latest.id DESC
+            LIMIT 1
+        )
+     LIMIT 1;`;

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -134,7 +134,19 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
         ) AS subordinateCount,
         e.employee_status AS employeeStatus,
         e.continuous_service_record AS continuousServiceRecord,
-        csr.start_date AS continuousServiceDate,
+        -- Walks the whole continuous-service chain, not one hop. An employee with three
+        -- linked employments (A -> B -> C) would otherwise report B's start date and
+        -- understate their service.
+        (
+            WITH RECURSIVE chain AS (
+                SELECT csr0.id, csr0.continuous_service_record, csr0.start_date
+                FROM employee csr0 WHERE csr0.id = e.continuous_service_record
+                UNION
+                SELECT csr1.id, csr1.continuous_service_record, csr1.start_date
+                FROM employee csr1 JOIN chain ON csr1.id = chain.continuous_service_record
+            )
+            SELECT MIN(chain.start_date) FROM chain
+        ) AS continuousServiceDate,
         e.probation_end_date AS probationEndDate,
         e.agreement_end_date AS agreementEndDate,
         r.date AS resignationDate,
@@ -189,7 +201,6 @@ isolated function getEmployeeInfoQuery(string employeeId) returns sql:Parameteri
         LEFT JOIN unit u ON e.unit_id = u.id
         LEFT JOIN house h ON e.house_id = h.id
         LEFT JOIN personal_info pi ON pi.id = e.personal_info_id
-        LEFT JOIN employee csr ON csr.id = e.continuous_service_record
         LEFT JOIN resignation r ON r.employee_id = e.id
     WHERE
         e.employee_id = ${employeeId};`;
@@ -220,7 +231,18 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
             COALESCE(sc.subordinateCount, 0) AS subordinateCount,
             e.employee_status AS employeeStatus,
             e.continuous_service_record AS continuousServiceRecord,
-            csr.start_date AS continuousServiceDate,
+            -- See the note on the single-employee query: this walks the whole chain
+            -- rather than one hop.
+            (
+                WITH RECURSIVE chain AS (
+                    SELECT csr0.id, csr0.continuous_service_record, csr0.start_date
+                    FROM employee csr0 WHERE csr0.id = e.continuous_service_record
+                    UNION
+                    SELECT csr1.id, csr1.continuous_service_record, csr1.start_date
+                    FROM employee csr1 JOIN chain ON csr1.id = chain.continuous_service_record
+                )
+                SELECT MIN(chain.start_date) FROM chain
+            ) AS continuousServiceDate,
             e.probation_end_date AS probationEndDate,
             e.agreement_end_date AS agreementEndDate,
             r.date AS resignationDate,
@@ -298,7 +320,6 @@ isolated function getEmployeesQuery(EmployeeSearchPayload payload, string? leadE
                 FROM employee
                 GROUP BY LOWER(work_email)
             ) mgr ON mgr.managerEmail = LOWER(e.manager_email)
-            LEFT JOIN employee csr ON csr.id = e.continuous_service_record
             LEFT JOIN resignation r ON r.employee_id = e.id
         `;
 

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2556,3 +2556,22 @@ isolated function getPersonalInfoAuditSnapshotsQuery(int[] employeePkIds) return
             )
             ORDER BY pia.action_on ASC`;
 }
+
+# Every id-to-name mapping needed to render history events, in one query.
+#
+# Audit snapshots store foreign keys (`unit_id`, `designation_id`, ...), which are
+# meaningless to a reader. This resolves them in a single round trip rather than one
+# query per lookup table. `designation` names its column `designation`; every other
+# lookup table uses `name`.
+#
+# + return - Parameterized query returning (field, id, name) rows
+isolated function getHistoryLookupNamesQuery() returns sql:ParameterizedQuery =>
+    `SELECT 'business_unit_id' AS field, id, name FROM business_unit
+     UNION ALL SELECT 'team_id', id, name FROM team
+     UNION ALL SELECT 'sub_team_id', id, name FROM sub_team
+     UNION ALL SELECT 'unit_id', id, name FROM unit
+     UNION ALL SELECT 'designation_id', id, designation FROM designation
+     UNION ALL SELECT 'employment_type_id', id, name FROM employment_type
+     UNION ALL SELECT 'company_id', id, name FROM company
+     UNION ALL SELECT 'office_id', id, name FROM office
+     UNION ALL SELECT 'house_id', id, name FROM house`;

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2482,8 +2482,30 @@ isolated function getEmploymentPeriodsQuery(string employeeId) returns sql:Param
         JOIN employment_type et ON et.id = e.employment_type_id
         LEFT JOIN resignation r ON r.employee_id = e.id
         LEFT JOIN employee csr ON csr.id = e.continuous_service_record
-    WHERE e.personal_info_id = (
-        SELECT personal_info_id FROM employee WHERE employee_id = ${employeeId}
+    WHERE e.id IN (
+        WITH RECURSIVE anchor AS (
+            SELECT id, personal_info_id, continuous_service_record
+            FROM employee WHERE employee_id = ${employeeId}
+        ),
+        -- Walk backwards: each row points at the employment that preceded it.
+        earlier AS (
+            SELECT id, continuous_service_record FROM anchor
+            UNION
+            SELECT e2.id, e2.continuous_service_record
+            FROM employee e2 JOIN earlier ON e2.id = earlier.continuous_service_record
+        ),
+        -- Walk forwards: find rows pointing back at anything already collected.
+        later AS (
+            SELECT id FROM anchor
+            UNION
+            SELECT e3.id
+            FROM employee e3 JOIN later ON e3.continuous_service_record = later.id
+        )
+        SELECT id FROM earlier
+        UNION SELECT id FROM later
+        -- Rehires where the identity record does match are still picked up here.
+        UNION SELECT e4.id FROM employee e4
+            JOIN anchor ON e4.personal_info_id = anchor.personal_info_id
     )
     ORDER BY e.start_date DESC`;
 

--- a/apps/people-app/backend/modules/database/db_queries.bal
+++ b/apps/people-app/backend/modules/database/db_queries.bal
@@ -2445,3 +2445,95 @@ isolated function deleteEmployeeEmergencyContactsAuditQuery(int personalInfoId) 
 # + return - Parameterized query to delete personal info audit rows
 isolated function deletePersonalInfoAuditQuery(int personalInfoId) returns sql:ParameterizedQuery =>
     `DELETE FROM personal_info_audit WHERE personal_info_pk_id = ${personalInfoId};`;
+
+# All employment periods for the person behind an employee ID.
+#
+# + employeeId - Employee ID of any one of the person's employment records
+# + return - Parameterized query returning every employment period, newest first
+isolated function getEmploymentPeriodsQuery(string employeeId) returns sql:ParameterizedQuery =>
+    `SELECT
+        e.id AS id,
+        e.employee_id AS employeeId,
+        et.name AS employmentType,
+        e.start_date AS startDate,
+        r.final_day_of_employment AS endDate,
+        e.work_email AS workEmail,
+        csr.employee_id AS continuousServiceRecord
+    FROM employee e
+        JOIN employment_type et ON et.id = e.employment_type_id
+        LEFT JOIN resignation r ON r.employee_id = e.id
+        LEFT JOIN employee csr ON csr.id = e.continuous_service_record
+    WHERE e.personal_info_id = (
+        SELECT personal_info_id FROM employee WHERE employee_id = ${employeeId}
+    )
+    ORDER BY e.start_date DESC`;
+
+# Fetch audit snapshots from the employee_audit table for a set of employee rows.
+#
+# + employeePkIds - Employee table primary keys belonging to the person
+# + return - Parameterized query returning employee_audit rows tagged with their source table
+isolated function getEmployeeAuditSnapshotsQuery(int[] employeePkIds) returns sql:ParameterizedQuery {
+    sql:ParameterizedQuery inClause = buildIntInClause(employeePkIds);
+    return sql:queryConcat(
+            `SELECT
+                employee_pk_id AS employeePkId,
+                'employee_audit' AS sourceTable,
+                action_type AS actionType,
+                action_by AS actionBy,
+                action_on AS actionOn,
+                data AS data
+            FROM employee_audit
+            WHERE employee_pk_id IN (`,
+            inClause,
+            `)
+            ORDER BY action_on ASC`
+    );
+}
+
+# Fetch audit snapshots from the employee_additional_managers_audit table for a set of employee rows.
+#
+# + employeePkIds - Employee table primary keys belonging to the person
+# + return - Parameterized query returning employee_additional_managers_audit rows tagged with their source table
+isolated function getEmployeeAdditionalManagersAuditSnapshotsQuery(int[] employeePkIds)
+    returns sql:ParameterizedQuery {
+    sql:ParameterizedQuery inClause = buildIntInClause(employeePkIds);
+    return sql:queryConcat(
+            `SELECT
+                employee_pk_id AS employeePkId,
+                'employee_additional_managers_audit' AS sourceTable,
+                action_type AS actionType,
+                action_by AS actionBy,
+                action_on AS actionOn,
+                data AS data
+            FROM employee_additional_managers_audit
+            WHERE employee_pk_id IN (`,
+            inClause,
+            `)
+            ORDER BY action_on ASC`
+    );
+}
+
+# Fetch audit snapshots from the personal_info_audit table for the person behind a set of employee rows.
+#
+# personal_info_audit keys on personal_info_pk_id, not employee_pk_id. All employee rows belonging to one
+# person share the same personal_info_id, so it is resolved once from any single employee primary key in
+# the set (the first one) rather than joined against the whole set, which would otherwise multiply rows.
+#
+# + employeePkIds - Employee table primary keys belonging to the person
+# + return - Parameterized query returning personal_info_audit rows tagged with their source table; each
+# row's employeePkId is the resolving employee primary key, not necessarily the one active at that time
+isolated function getPersonalInfoAuditSnapshotsQuery(int[] employeePkIds) returns sql:ParameterizedQuery {
+    int anchorEmployeePkId = employeePkIds[0];
+    return `SELECT
+                ${anchorEmployeePkId} AS employeePkId,
+                'personal_info_audit' AS sourceTable,
+                pia.action_type AS actionType,
+                pia.action_by AS actionBy,
+                pia.action_on AS actionOn,
+                pia.data AS data
+            FROM personal_info_audit pia
+            WHERE pia.personal_info_pk_id = (
+                SELECT personal_info_id FROM employee WHERE id = ${anchorEmployeePkId}
+            )
+            ORDER BY pia.action_on ASC`;
+}

--- a/apps/people-app/backend/modules/database/history.bal
+++ b/apps/people-app/backend/modules/database/history.bal
@@ -142,3 +142,44 @@ isolated function toDisplayValue(json value) returns string? {
 isolated function isSystemActor(string actionBy) returns boolean {
     return SYSTEM_ACTORS.indexOf(actionBy) !is ();
 }
+
+# Resolve raw foreign-key values on history events to human-readable names.
+#
+# Events arrive carrying ids from the audit snapshots ("87"). Anything that has a mapping
+# is replaced with its name; values with no mapping (a deleted lookup row, or a field that
+# was never an id) are left exactly as they are rather than blanked, so nothing disappears
+# from the timeline.
+#
+# + events - History events carrying raw values
+# + lookup - Field -> id -> name mapping
+# + return - Events with id values replaced by names where a mapping exists
+public isolated function resolveHistoryEventNames(HistoryEvent[] events, map<map<string>> lookup)
+        returns HistoryEvent[] =>
+    from HistoryEvent event in events
+    select {
+        employeePkId: event.employeePkId,
+        'field: event.'field,
+        previousValue: resolveLookupValue(event.'field, event.previousValue, lookup),
+        currentValue: resolveLookupValue(event.'field, event.currentValue, lookup),
+        occurredOn: event.occurredOn,
+        actionBy: event.actionBy,
+        isSystem: event.isSystem
+    };
+
+# Replace a single id with its name when a mapping exists.
+#
+# + field - The audit field the value belongs to
+# + value - The raw value, possibly an id
+# + lookup - Field -> id -> name mapping
+# + return - The resolved name, or the original value when there is no mapping
+isolated function resolveLookupValue(string 'field, string? value, map<map<string>> lookup)
+        returns string? {
+    if value is () {
+        return ();
+    }
+    if !lookup.hasKey('field) {
+        return value;
+    }
+    map<string> byId = lookup.get('field);
+    return byId.hasKey(value) ? byId.get(value) : value;
+}

--- a/apps/people-app/backend/modules/database/history.bal
+++ b/apps/people-app/backend/modules/database/history.bal
@@ -20,6 +20,16 @@ const SOURCE_TABLE_EMPLOYEE_AUDIT = "employee_audit";
 # Source table name for personal_info_audit snapshots.
 const SOURCE_TABLE_PERSONAL_INFO_AUDIT = "personal_info_audit";
 
+# Source table name for employee_additional_managers_audit snapshots.
+const SOURCE_TABLE_ADDITIONAL_MANAGERS_AUDIT = "employee_additional_managers_audit";
+
+# Synthetic field name for additional-manager events, which describe a relationship
+# rather than a column on the employee row.
+const FIELD_ADDITIONAL_MANAGER = "additional_manager";
+
+# Action type recorded when a row is soft-deleted (is_active flipped to 0).
+const ACTION_TYPE_DELETE = "DELETE";
+
 # Action type recorded for a row insert.
 const ACTION_TYPE_INSERT = "INSERT";
 
@@ -86,9 +96,9 @@ isolated function trackedFieldsFor(string sourceTable) returns string[] {
 # different columns under partly overlapping names, so a cross-table comparison would
 # report tracked fields flipping to null purely because the other table lacks them.
 #
-# Each source table has its own tracked field list. employee_audit and personal_info_audit
-# both produce events; employee_additional_managers_audit is fetched for completeness but
-# has no tracked fields, so it establishes baselines and emits nothing.
+# employee_audit and personal_info_audit are diffed field by field.
+# employee_additional_managers_audit is not: each of its rows is one manager
+# relationship, so the row being added or removed is itself the event.
 #
 # + snapshots - Audit snapshots ordered oldest first
 # + return - One event per changed tracked field, newest first
@@ -100,6 +110,17 @@ public isolated function buildHistoryEvents(AuditSnapshot[] snapshots) returns H
     map<json> previousByRecord = {};
 
     foreach AuditSnapshot snapshot in snapshots {
+        // An additional-manager row describes a relationship, not a column on the
+        // employee: its existence is the event. Handled before the field diff, which
+        // has nothing to compare for it.
+        if snapshot.sourceTable == SOURCE_TABLE_ADDITIONAL_MANAGERS_AUDIT {
+            HistoryEvent? managerEvent = buildAdditionalManagerEvent(snapshot);
+            if managerEvent is HistoryEvent {
+                events.push(managerEvent);
+            }
+            continue;
+        }
+
         string recordKey = string `${snapshot.employeePkId}|${snapshot.sourceTable}`;
 
         // hasKey, not `previous is json`: a JSON null is itself a valid json value, so an
@@ -137,6 +158,44 @@ public isolated function buildHistoryEvents(AuditSnapshot[] snapshots) returns H
     }
 
     return events.reverse();
+}
+
+# Build an event for an additional-manager row.
+#
+# Unlike the employee and personal-info tables, there is nothing to diff here: one row is
+# one manager relationship, so an INSERT is an addition and the trigger records a DELETE
+# when is_active flips to 0. An UPDATE that leaves the row active is a no-op re-save and
+# yields nothing, so a bulk re-write cannot fill the timeline with noise.
+#
+# + snapshot - Audit snapshot from employee_additional_managers_audit
+# + return - The event, or () when the snapshot records no meaningful change
+isolated function buildAdditionalManagerEvent(AuditSnapshot snapshot) returns HistoryEvent? {
+    string? managerEmail = toDisplayValue(getField(snapshot.data, "additional_manager_email"));
+    if managerEmail is () {
+        return ();
+    }
+
+    boolean isRemoval = snapshot.actionType == ACTION_TYPE_DELETE
+        || toDisplayValue(getField(snapshot.data, "is_active")) == "0";
+    boolean isAddition = snapshot.actionType == ACTION_TYPE_INSERT;
+
+    if !isRemoval && !isAddition {
+        return ();
+    }
+
+    return {
+        employeePkId: snapshot.employeePkId,
+        'field: FIELD_ADDITIONAL_MANAGER,
+        sourceTable: snapshot.sourceTable,
+        // Rendered by the existing old -> new treatment: an addition has no previous
+        // value, and a removal has no current one, which the timeline already draws as
+        // "added" and "Removed" respectively.
+        previousValue: isRemoval ? managerEmail : (),
+        currentValue: isRemoval ? () : managerEmail,
+        occurredOn: snapshot.actionOn,
+        actionBy: snapshot.actionBy,
+        isSystem: isSystemActor(snapshot.actionBy)
+    };
 }
 
 # Read a member from a JSON snapshot without failing when it is absent.

--- a/apps/people-app/backend/modules/database/history.bal
+++ b/apps/people-app/backend/modules/database/history.bal
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Source table name for employee_audit snapshots.
+const SOURCE_TABLE_EMPLOYEE_AUDIT = "employee_audit";
+
+# Action type recorded for a row insert.
+const ACTION_TYPE_INSERT = "INSERT";
+
+# Actors that are automated processes rather than people.
+final readonly & string[] SYSTEM_ACTORS = ["MIGRATION", "system-scheduler"];
+
+# Employee fields surfaced in the history. Everything else in the audit
+# snapshot is either noise or not meaningful to a reader.
+#
+# Deliberately excluded as noise: updated_on, updated_by, created_on, created_by,
+# employee_thumbnail and id. Bulk migrations re-write those columns on rows whose
+# meaningful values never changed, so diffing them buries the real changes.
+final readonly & string[] TRACKED_EMPLOYEE_FIELDS = [
+    "business_unit_id", "team_id", "sub_team_id", "unit_id",
+    "designation_id", "employment_type_id", "company_id", "office_id",
+    "manager_email", "employee_status", "work_location",
+    "job_role", "secondary_job_title", "external_designation",
+    "house_id", "epf", "probation_end_date", "agreement_end_date", "start_date"
+];
+
+# Derive field-level change events by comparing consecutive audit snapshots.
+#
+# Snapshots must arrive ordered by action_on ascending. They may interleave rows from
+# several employee records and several source tables; this function separates those
+# streams itself rather than assuming the caller has grouped them.
+#
+# Three properties make the derived history truthful:
+#
+# 1. An INSERT yields no change events. It is the baseline that the next UPDATE is
+# compared against, not a change in its own right. Treating it as a change would make
+# every field appear to change on the employee's first day.
+#
+# 2. Snapshots are compared within a single employee record. A person may hold several
+# employee rows over time (a rehire), and their snapshots interleave in one time-ordered
+# stream. Comparing across records would invent transitions that never happened.
+#
+# 3. Snapshots are compared within a single source table. The three audit tables carry
+# different columns under partly overlapping names, so a cross-table comparison would
+# report tracked fields flipping to null purely because the other table lacks them.
+#
+# Only TRACKED_EMPLOYEE_FIELDS produce events; all of them live in employee_audit, so
+# snapshots from the other audit tables establish baselines but currently emit nothing.
+#
+# + snapshots - Audit snapshots ordered oldest first
+# + return - One event per changed tracked field, newest first
+public isolated function buildHistoryEvents(AuditSnapshot[] snapshots) returns HistoryEvent[] {
+    HistoryEvent[] events = [];
+
+    // Keyed by employee record *and* source table, so neither a rehire nor a different
+    // audit table is ever compared against the wrong baseline.
+    map<json> previousByRecord = {};
+
+    foreach AuditSnapshot snapshot in snapshots {
+        string recordKey = string `${snapshot.employeePkId}|${snapshot.sourceTable}`;
+
+        // hasKey, not `previous is json`: a JSON null is itself a valid json value, so an
+        // absent baseline and a stored null are indistinguishable by type alone.
+        boolean hasBaseline = previousByRecord.hasKey(recordKey);
+        json previous = previousByRecord[recordKey] ?: ();
+
+        // An INSERT restarts the baseline for this record rather than being diffed
+        // against whatever preceded it.
+        boolean isBaseline = snapshot.actionType == ACTION_TYPE_INSERT;
+
+        if hasBaseline && !isBaseline && snapshot.sourceTable == SOURCE_TABLE_EMPLOYEE_AUDIT {
+            foreach string 'field in TRACKED_EMPLOYEE_FIELDS {
+                json previousValue = getField(previous, 'field);
+                json currentValue = getField(snapshot.data, 'field);
+
+                if previousValue != currentValue {
+                    events.push({
+                        employeePkId: snapshot.employeePkId,
+                        'field: 'field,
+                        previousValue: toDisplayValue(previousValue),
+                        currentValue: toDisplayValue(currentValue),
+                        occurredOn: snapshot.actionOn,
+                        actionBy: snapshot.actionBy,
+                        isSystem: isSystemActor(snapshot.actionBy)
+                    });
+                }
+            }
+        }
+
+        previousByRecord[recordKey] = snapshot.data;
+    }
+
+    return events.reverse();
+}
+
+# Read a member from a JSON snapshot without failing when it is absent.
+#
+# Audit payloads are written by database triggers whose column set has changed over
+# time, so older rows legitimately lack fields that newer rows carry.
+#
+# + data - JSON snapshot to read from
+# + fieldName - Member name to read
+# + return - The member value, or () when the snapshot is not an object or lacks the member
+isolated function getField(json data, string fieldName) returns json {
+    if data is map<json> {
+        return data[fieldName];
+    }
+    return ();
+}
+
+# Render a JSON scalar as the string shown in the timeline.
+#
+# + value - JSON value taken from an audit snapshot
+# + return - String form of the scalar, or () when the value is absent or JSON null
+isolated function toDisplayValue(json value) returns string? {
+    if value is () {
+        return ();
+    }
+    if value is string {
+        return value;
+    }
+    return value.toString();
+}
+
+# Check whether an audit actor is an automated process rather than a person.
+#
+# + actionBy - Value of the audit row's action_by column
+# + return - True when the actor is a known system actor
+isolated function isSystemActor(string actionBy) returns boolean {
+    return SYSTEM_ACTORS.indexOf(actionBy) !is ();
+}

--- a/apps/people-app/backend/modules/database/history.bal
+++ b/apps/people-app/backend/modules/database/history.bal
@@ -17,6 +17,9 @@
 # Source table name for employee_audit snapshots.
 const SOURCE_TABLE_EMPLOYEE_AUDIT = "employee_audit";
 
+# Source table name for personal_info_audit snapshots.
+const SOURCE_TABLE_PERSONAL_INFO_AUDIT = "personal_info_audit";
+
 # Action type recorded for a row insert.
 const ACTION_TYPE_INSERT = "INSERT";
 
@@ -36,6 +39,32 @@ final readonly & string[] TRACKED_EMPLOYEE_FIELDS = [
     "job_role", "secondary_job_title", "external_designation",
     "house_id", "epf", "probation_end_date", "agreement_end_date", "start_date"
 ];
+
+# Personal information fields surfaced in the history.
+#
+# `full_name` is deliberately excluded: it is generated from first_name and last_name, so
+# tracking it would emit a second event for every name change. The audit columns
+# (created_*, updated_*, id) are excluded for the same reason as on the employee table.
+final readonly & string[] TRACKED_PERSONAL_INFO_FIELDS = [
+    "nic_or_passport", "first_name", "last_name", "title", "dob", "gender",
+    "personal_email", "personal_phone", "resident_number",
+    "address_line_1", "address_line_2", "city", "state_or_province",
+    "postal_code", "country", "nationality"
+];
+
+# The tracked field list for a given audit source.
+#
+# + sourceTable - Audit table the snapshot came from
+# + return - Fields to diff for that source; empty when the source is not tracked
+isolated function trackedFieldsFor(string sourceTable) returns string[] {
+    if sourceTable == SOURCE_TABLE_EMPLOYEE_AUDIT {
+        return TRACKED_EMPLOYEE_FIELDS;
+    }
+    if sourceTable == SOURCE_TABLE_PERSONAL_INFO_AUDIT {
+        return TRACKED_PERSONAL_INFO_FIELDS;
+    }
+    return [];
+}
 
 # Derive field-level change events by comparing consecutive audit snapshots.
 #
@@ -57,8 +86,9 @@ final readonly & string[] TRACKED_EMPLOYEE_FIELDS = [
 # different columns under partly overlapping names, so a cross-table comparison would
 # report tracked fields flipping to null purely because the other table lacks them.
 #
-# Only TRACKED_EMPLOYEE_FIELDS produce events; all of them live in employee_audit, so
-# snapshots from the other audit tables establish baselines but currently emit nothing.
+# Each source table has its own tracked field list. employee_audit and personal_info_audit
+# both produce events; employee_additional_managers_audit is fetched for completeness but
+# has no tracked fields, so it establishes baselines and emits nothing.
 #
 # + snapshots - Audit snapshots ordered oldest first
 # + return - One event per changed tracked field, newest first
@@ -81,8 +111,10 @@ public isolated function buildHistoryEvents(AuditSnapshot[] snapshots) returns H
         // against whatever preceded it.
         boolean isBaseline = snapshot.actionType == ACTION_TYPE_INSERT;
 
-        if hasBaseline && !isBaseline && snapshot.sourceTable == SOURCE_TABLE_EMPLOYEE_AUDIT {
-            foreach string 'field in TRACKED_EMPLOYEE_FIELDS {
+        string[] trackedFields = trackedFieldsFor(snapshot.sourceTable);
+
+        if hasBaseline && !isBaseline && trackedFields.length() > 0 {
+            foreach string 'field in trackedFields {
                 json previousValue = getField(previous, 'field);
                 json currentValue = getField(snapshot.data, 'field);
 
@@ -90,6 +122,7 @@ public isolated function buildHistoryEvents(AuditSnapshot[] snapshots) returns H
                     events.push({
                         employeePkId: snapshot.employeePkId,
                         'field: 'field,
+                        sourceTable: snapshot.sourceTable,
                         previousValue: toDisplayValue(previousValue),
                         currentValue: toDisplayValue(currentValue),
                         occurredOn: snapshot.actionOn,
@@ -159,6 +192,7 @@ public isolated function resolveHistoryEventNames(HistoryEvent[] events, map<map
     select {
         employeePkId: event.employeePkId,
         'field: event.'field,
+        sourceTable: event.sourceTable,
         previousValue: resolveLookupValue(event.'field, event.previousValue, lookup),
         currentValue: resolveLookupValue(event.'field, event.currentValue, lookup),
         occurredOn: event.occurredOn,

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -1387,3 +1387,21 @@ public type AuditSnapshot record {|
     # The full row snapshot as JSON
     json data;
 |};
+
+# One field-level change derived from consecutive audit snapshots.
+public type HistoryEvent record {|
+    # Employee table primary key this event belongs to
+    int employeePkId;
+    # Canonical field key (e.g. "team_id")
+    string 'field;
+    # Value before the change, if any
+    string? previousValue;
+    # Value after the change
+    string? currentValue;
+    # When the change occurred
+    string occurredOn;
+    # Who made the change
+    string actionBy;
+    # True when actionBy is a system actor rather than a person
+    boolean isSystem;
+|};

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -1405,3 +1405,13 @@ public type HistoryEvent record {|
     # True when actionBy is a system actor rather than a person
     boolean isSystem;
 |};
+
+# One id-to-name mapping row used to resolve history event values.
+public type HistoryLookupName record {|
+    # The audit field this mapping applies to, e.g. "unit_id"
+    string 'field;
+    # The lookup row's primary key
+    int id;
+    # The human-readable name
+    string name;
+|};

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -1394,6 +1394,9 @@ public type HistoryEvent record {|
     int employeePkId;
     # Canonical field key (e.g. "team_id")
     string 'field;
+    # Audit table the change came from, so the client can group events by kind
+    # (employment vs personal information) without inferring it from the field name
+    string sourceTable;
     # Value before the change, if any
     string? previousValue;
     # Value after the change

--- a/apps/people-app/backend/modules/database/types.bal
+++ b/apps/people-app/backend/modules/database/types.bal
@@ -1353,3 +1353,37 @@ type CompanyOrgChartBusinessUnitRow record {|
     # Teams with nested sub-teams and units as raw JSON.
     json teams;
 |};
+
+# One employment period for a person.
+public type EmploymentPeriod record {|
+    # Employee table primary key
+    int id;
+    # Employee ID (e.g. "EP 10006")
+    string? employeeId;
+    # Employment type name
+    string employmentType;
+    # Start date
+    string startDate;
+    # Final day of employment, if the period has ended
+    string? endDate;
+    # Work email
+    string workEmail;
+    # Employee ID of the prior linked employment, if any
+    string? continuousServiceRecord;
+|};
+
+# A raw audit row awaiting diffing.
+public type AuditSnapshot record {|
+    # Employee table primary key this snapshot belongs to
+    int employeePkId;
+    # Source table this snapshot came from
+    string sourceTable;
+    # INSERT or UPDATE
+    string actionType;
+    # Who performed the action
+    string actionBy;
+    # When the action occurred
+    string actionOn;
+    # The full row snapshot as JSON
+    json data;
+|};

--- a/apps/people-app/backend/modules/promotion/client.bal
+++ b/apps/people-app/backend/modules/promotion/client.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerinax/mysql;
+import ballerinax/mysql.driver as _;
+
+# HRIS promotion database client configuration.
+configurable PromotionDatabaseConfig promotionDbConfig = ?;
+
+function initPromotionDbClient() returns mysql:Client|error => new (...promotionDbConfig);
+
+# HRIS promotion database client.
+final mysql:Client promotionDbClient = check initPromotionDbClient();

--- a/apps/people-app/backend/modules/promotion/functions.bal
+++ b/apps/people-app/backend/modules/promotion/functions.bal
@@ -28,6 +28,7 @@ public isolated function getApprovedPromotions(string workEmail) returns Promoti
     // Promoted dates are inconsistently stored; some use slashes. The promotion app
     // normalises the same way (promotion-app functions.bal:132).
     return from PromotionRecord promotion in promotions
+        let string? promotedDate = promotion.promotedDate
         select {
             currentJobBand: promotion.currentJobBand,
             nextJobBand: promotion.nextJobBand,
@@ -41,8 +42,10 @@ public isolated function getApprovedPromotions(string workEmail) returns Promoti
             // createdOn comes from a TIMESTAMP column via DATE(), so it is always
             // YYYY-MM-DD and needs no normalisation.
             createdOn: promotion.createdOn,
-            promotedDate: promotion.promotedDate is string
-                ? re `/`.replaceAll(<string>promotion.promotedDate, "-")
+            // Bound to a local above: narrowing does not apply to record field
+            // access, so reading the field directly would still need a cast here.
+            promotedDate: promotedDate is string
+                ? re `/`.replaceAll(promotedDate, "-")
                 : ()
         };
 }

--- a/apps/people-app/backend/modules/promotion/functions.bal
+++ b/apps/people-app/backend/modules/promotion/functions.bal
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Fetch approved promotions for an employee from the HRIS database.
+#
+# + workEmail - Work email of the employee
+# + return - Approved promotions newest first, or an error
+public isolated function getApprovedPromotions(string workEmail) returns PromotionRecord[]|error {
+    stream<PromotionRecord, error?> resultStream =
+        promotionDbClient->query(getApprovedPromotionsQuery(workEmail));
+
+    PromotionRecord[] promotions = check from PromotionRecord promotion in resultStream
+        select promotion;
+
+    // Promoted dates are inconsistently stored; some use slashes. The promotion app
+    // normalises the same way (promotion-app functions.bal:132).
+    return from PromotionRecord promotion in promotions
+        select {
+            currentJobBand: promotion.currentJobBand,
+            nextJobBand: promotion.nextJobBand,
+            jobRole: promotion.jobRole,
+            promotionType: promotion.promotionType,
+            cycleName: promotion.cycleName,
+            businessUnit: promotion.businessUnit,
+            department: promotion.department,
+            team: promotion.team,
+            subTeam: promotion.subTeam,
+            promotedDate: re `/`.replaceAll(promotion.promotedDate, "-")
+        };
+}

--- a/apps/people-app/backend/modules/promotion/functions.bal
+++ b/apps/people-app/backend/modules/promotion/functions.bal
@@ -38,6 +38,9 @@ public isolated function getApprovedPromotions(string workEmail) returns Promoti
             department: promotion.department,
             team: promotion.team,
             subTeam: promotion.subTeam,
+            // createdOn comes from a TIMESTAMP column via DATE(), so it is always
+            // YYYY-MM-DD and needs no normalisation.
+            createdOn: promotion.createdOn,
             promotedDate: promotion.promotedDate is string
                 ? re `/`.replaceAll(<string>promotion.promotedDate, "-")
                 : ()

--- a/apps/people-app/backend/modules/promotion/functions.bal
+++ b/apps/people-app/backend/modules/promotion/functions.bal
@@ -38,6 +38,8 @@ public isolated function getApprovedPromotions(string workEmail) returns Promoti
             department: promotion.department,
             team: promotion.team,
             subTeam: promotion.subTeam,
-            promotedDate: re `/`.replaceAll(promotion.promotedDate, "-")
+            promotedDate: promotion.promotedDate is string
+                ? re `/`.replaceAll(<string>promotion.promotedDate, "-")
+                : ()
         };
 }

--- a/apps/people-app/backend/modules/promotion/queries.bal
+++ b/apps/people-app/backend/modules/promotion/queries.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/sql;
+
+# Approved promotions for an employee, from cycles that have formally ended.
+#
+# + workEmail - Work email of the employee
+# + return - Parameterized query returning approved promotions, newest first
+isolated function getApprovedPromotionsQuery(string workEmail) returns sql:ParameterizedQuery =>
+    `SELECT
+        pr.promotion_request_promoted_date AS promotedDate,
+        pr.promotion_request_current_job_band AS currentJobBand,
+        pr.promotion_request_requested_job_band AS nextJobBand,
+        pr.promotion_request_current_job_role AS jobRole,
+        pr.promotion_request_type AS promotionType,
+        pr.promotion_request_business_unit AS businessUnit,
+        pr.promotion_request_department AS department,
+        pr.promotion_request_team AS team,
+        pr.promotion_request_sub_team AS subTeam,
+        pc.promotion_cycle_name AS cycleName
+    FROM hris_promotion_request pr
+        JOIN hris_promotion_cycle pc ON pc.promotion_cycle_id = pr.promotion_cycle_id
+    WHERE pr.promotion_request_employee_email = ${workEmail}
+        AND pr.promotion_request_status = 'APPROVED'
+        AND pc.promotion_cycle_status = 'END'
+        AND pr.promotion_request_promoted_date IS NOT NULL
+    ORDER BY pr.promotion_request_promoted_date DESC`;

--- a/apps/people-app/backend/modules/promotion/queries.bal
+++ b/apps/people-app/backend/modules/promotion/queries.bal
@@ -36,5 +36,4 @@ isolated function getApprovedPromotionsQuery(string workEmail) returns sql:Param
     WHERE pr.promotion_request_employee_email = ${workEmail}
         AND pr.promotion_request_status = 'APPROVED'
         AND pc.promotion_cycle_status = 'END'
-        AND pr.promotion_request_promoted_date IS NOT NULL
     ORDER BY pr.promotion_request_promoted_date DESC`;

--- a/apps/people-app/backend/modules/promotion/queries.bal
+++ b/apps/people-app/backend/modules/promotion/queries.bal
@@ -22,6 +22,7 @@ import ballerina/sql;
 isolated function getApprovedPromotionsQuery(string workEmail) returns sql:ParameterizedQuery =>
     `SELECT
         pr.promotion_request_promoted_date AS promotedDate,
+        DATE(pr.promotion_request_created_on) AS createdOn,
         pr.promotion_request_current_job_band AS currentJobBand,
         pr.promotion_request_requested_job_band AS nextJobBand,
         pr.promotion_request_current_job_role AS jobRole,
@@ -36,4 +37,4 @@ isolated function getApprovedPromotionsQuery(string workEmail) returns sql:Param
     WHERE pr.promotion_request_employee_email = ${workEmail}
         AND pr.promotion_request_status = 'APPROVED'
         AND pc.promotion_cycle_status = 'END'
-    ORDER BY pr.promotion_request_promoted_date DESC`;
+    ORDER BY pr.promotion_request_created_on DESC`;

--- a/apps/people-app/backend/modules/promotion/types.bal
+++ b/apps/people-app/backend/modules/promotion/types.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/sql;
+import ballerinax/mysql;
 
 # HRIS promotion database configuration.
 public type PromotionDatabaseConfig record {|
@@ -28,6 +29,10 @@ public type PromotionDatabaseConfig record {|
     string host;
     # Port number of the MySQL server
     int port;
+    # The `mysql:Options` configurations. Present so a cross-machine connection to the
+    # HRIS host can be given a TLS mode and a connect timeout, as the primary database
+    # config already can.
+    mysql:Options options?;
     # Connection pool configuration
     sql:ConnectionPool connectionPool?;
 |};

--- a/apps/people-app/backend/modules/promotion/types.bal
+++ b/apps/people-app/backend/modules/promotion/types.bal
@@ -26,6 +26,8 @@ public type PromotionDatabaseConfig record {|
     string database;
     # Database host
     string host;
+    # Port number of the MySQL server
+    int port;
     # Connection pool configuration
     sql:ConnectionPool connectionPool?;
 |};

--- a/apps/people-app/backend/modules/promotion/types.bal
+++ b/apps/people-app/backend/modules/promotion/types.bal
@@ -34,8 +34,9 @@ public type PromotionDatabaseConfig record {|
 
 # Approved promotion record for an employee.
 public type PromotionRecord record {|
-    # Date the promotion took effect
-    string promotedDate;
+    # Date the promotion took effect. Nullable: real data contains APPROVED
+    # promotions in ended cycles whose promoted date was never populated.
+    string? promotedDate;
     # Job band held before the promotion
     string currentJobBand;
     # Job band granted by the promotion

--- a/apps/people-app/backend/modules/promotion/types.bal
+++ b/apps/people-app/backend/modules/promotion/types.bal
@@ -34,9 +34,13 @@ public type PromotionDatabaseConfig record {|
 
 # Approved promotion record for an employee.
 public type PromotionRecord record {|
-    # Date the promotion took effect. Nullable: real data contains APPROVED
+    # Date the promotion took effect. Nullable: HRIS contains APPROVED
     # promotions in ended cycles whose promoted date was never populated.
     string? promotedDate;
+    # Date the promotion request was raised. This is what places a promotion on
+    # the timeline: it always falls inside exactly one employment period, which
+    # is how a promotion is attributed to the employment it belongs to.
+    string createdOn;
     # Job band held before the promotion
     string currentJobBand;
     # Job band granted by the promotion

--- a/apps/people-app/backend/modules/promotion/types.bal
+++ b/apps/people-app/backend/modules/promotion/types.bal
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/sql;
+
+# HRIS promotion database configuration.
+public type PromotionDatabaseConfig record {|
+    # Database user
+    string user;
+    # Database password
+    string password;
+    # Database name
+    string database;
+    # Database host
+    string host;
+    # Connection pool configuration
+    sql:ConnectionPool connectionPool?;
+|};
+
+# Approved promotion record for an employee.
+public type PromotionRecord record {|
+    # Date the promotion took effect
+    string promotedDate;
+    # Job band held before the promotion
+    string currentJobBand;
+    # Job band granted by the promotion
+    string nextJobBand;
+    # Job role at the time of promotion
+    string jobRole;
+    # Type of promotion
+    string promotionType;
+    # Name of the promotion cycle
+    string cycleName;
+    # Business unit at the time of promotion
+    string businessUnit;
+    # Department at the time of promotion
+    string department;
+    # Team at the time of promotion
+    string team;
+    # Sub-team at the time of promotion
+    string subTeam;
+|};

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -2981,6 +2981,17 @@ service http:InterceptableService / on new http:Listener(9090) {
 
         database:HistoryEvent[] events = database:buildHistoryEvents(snapshots);
 
+        // Audit snapshots store foreign keys, so an event reads "87" until its id is
+        // resolved. A lookup failure degrades to raw ids rather than failing the request —
+        // an unhelpful timeline is better than none.
+        map<map<string>>|error lookupNames = database:getHistoryLookupNames();
+        if lookupNames is map<map<string>> {
+            events = database:resolveHistoryEventNames(events, lookupNames);
+        } else {
+            log:printError("Error resolving history lookup names; returning raw ids",
+                    lookupNames, employeeId = employeeId);
+        }
+
         // The HRIS promotion database is a second database. An outage there must degrade the
         // timeline rather than break the employee's own profile page, so the failure is
         // reported as a flag alongside an otherwise complete response.

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -2897,14 +2897,36 @@ service http:InterceptableService / on new http:Listener(9090) {
             };
         }
 
-        boolean hasAdminAccess = authorization:checkPermissions(
+        // Access and projection are one decision, carried by one variable, so a caller can never
+        // be granted access under one tier and then filtered under another.
+        //
+        // - ADMIN, and a LEAD viewing their own subordinate, get the full projection:
+        //   attribution and system rows included. A lead can already see a subordinate's
+        //   designation, manager, status and dates through the sibling employee endpoint;
+        //   history adds only *when* those changed, so withholding it would be inconsistent.
+        // - Self gets the employee projection: no actionBy, no system rows.
+        boolean hasFullProjection = authorization:checkPermissions(
                 [authorization:authorizedRoles.ADMIN_ROLE], userInfo.groups);
+
+        if !hasFullProjection {
+            // Deliberately checked against the requested employeeId itself, never resolved
+            // through personal_info_id first. The lead relationship is carried by manager_email
+            // on an individual employment row, so resolving to the person would let a lead reach
+            // a former employment period of someone who is no longer their report.
+            boolean|error isSubordinate = database:isSubordinateOfLead(userInfo.email, employeeId);
+            if isSubordinate is error {
+                string customErr = string `Error occurred while checking lead authorization for ID: ${employeeId}`;
+                log:printError(customErr, isSubordinate, employeeId = employeeId);
+                return <http:InternalServerError>{body: {message: customErr}};
+            }
+            hasFullProjection = isSubordinate;
+        }
 
         // Authorization compares *people*, not employee IDs. A rehired person holds several
         // employee IDs against one personal_info row (e.g. intern "IN 0456" then permanent
         // "EP 10006"), so comparing the caller's employee ID against the requested one would
-        // deny them their own earlier employment. Admins bypass the check entirely.
-        if !hasAdminAccess {
+        // deny them their own earlier employment. Admins and leads-of-this-report skip this.
+        if !hasFullProjection {
             int?|error callerPersonalInfoId = database:getPersonalInfoIdByWorkEmail(userInfo.email);
             if callerPersonalInfoId is error {
                 string customErr = "Error occurred while resolving the invoker's employee record";
@@ -2978,7 +3000,7 @@ service http:InterceptableService / on new http:Listener(9090) {
 
         return {
             periods: periodResponses,
-            events: projectHistoryEvents(events, hasAdminAccess),
+            events: projectHistoryEvents(events, hasFullProjection),
             promotionsUnavailable: promotionsUnavailable
         };
     }

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -2909,17 +2909,34 @@ service http:InterceptableService / on new http:Listener(9090) {
                 [authorization:authorizedRoles.ADMIN_ROLE], userInfo.groups);
 
         if !hasFullProjection {
-            // Deliberately checked against the requested employeeId itself, never resolved
-            // through personal_info_id first. The lead relationship is carried by manager_email
-            // on an individual employment row, so resolving to the person would let a lead reach
-            // a former employment period of someone who is no longer their report.
+            // Two conditions, and both are required.
+            //
+            // `manager_email` is never cleared when an employment ends, so an old row names its
+            // former manager forever. The subordinate check alone would therefore let a former
+            // lead pass by quoting a stale employee ID — and because the response fans out to
+            // every period for that person, they would receive the current employment too.
+            // Requiring the requested row to be the person's current employment closes that:
+            // the lead projection is granted only for someone they still manage today.
             boolean|error isSubordinate = database:isSubordinateOfLead(userInfo.email, employeeId);
             if isSubordinate is error {
                 string customErr = string `Error occurred while checking lead authorization for ID: ${employeeId}`;
                 log:printError(customErr, isSubordinate, employeeId = employeeId);
                 return <http:InternalServerError>{body: {message: customErr}};
             }
-            hasFullProjection = isSubordinate;
+
+            if isSubordinate {
+                boolean|error isCurrent = database:isCurrentEmployment(employeeId);
+                if isCurrent is error {
+                    string customErr = string `Error occurred while checking employment currency for ID: ${employeeId}`;
+                    log:printError(customErr, isCurrent, employeeId = employeeId);
+                    return <http:InternalServerError>{body: {message: customErr}};
+                }
+                if !isCurrent {
+                    log:printWarn("Lead access denied: requested employment is not the person's current one",
+                            invokerEmail = userInfo.email, employeeId = employeeId);
+                }
+                hasFullProjection = isCurrent;
+            }
         }
 
         // Authorization compares *people*, not employee IDs. A rehired person holds several
@@ -2997,14 +3014,27 @@ service http:InterceptableService / on new http:Listener(9090) {
         // reported as a flag alongside an otherwise complete response.
         boolean promotionsUnavailable = false;
         promotion:PromotionRecord[] promotions = [];
-        string workEmail = periods[0].workEmail;
-        promotion:PromotionRecord[]|error fetchedPromotions = promotion:getApprovedPromotions(workEmail);
-        if fetchedPromotions is error {
-            promotionsUnavailable = true;
-            log:printError("Error occurred while fetching promotions from HRIS; returning history without them",
-                    fetchedPromotions, employeeId = employeeId);
-        } else {
-            promotions = fetchedPromotions;
+
+        // work_email lives on the employment row, and a chain is walked by
+        // continuous_service_record rather than by email, so periods can legitimately carry
+        // different emails. Querying only the newest one would silently omit promotions
+        // raised under a former address.
+        string[] workEmails = [];
+        foreach database:EmploymentPeriod period in periods {
+            if period.workEmail.trim() != "" && workEmails.indexOf(period.workEmail) is () {
+                workEmails.push(period.workEmail);
+            }
+        }
+
+        foreach string workEmail in workEmails {
+            promotion:PromotionRecord[]|error fetched = promotion:getApprovedPromotions(workEmail);
+            if fetched is error {
+                promotionsUnavailable = true;
+                log:printError("Error occurred while fetching promotions from HRIS; returning history without them",
+                        fetched, employeeId = employeeId, workEmail = workEmail);
+            } else {
+                promotions.push(...fetched);
+            }
         }
 
         EmploymentPeriodResponse[] periodResponses = assignPromotionsToPeriods(periods, promotions);

--- a/apps/people-app/backend/service.bal
+++ b/apps/people-app/backend/service.bal
@@ -16,6 +16,7 @@
 
 import people.authorization;
 import people.database;
+import people.promotion;
 import people.qr;
 import people.wso2_coin;
 // Temporarily disabled together with the Asgardeo/SCIM provisioning blocks in the onboarding
@@ -2874,5 +2875,111 @@ service http:InterceptableService / on new http:Listener(9090) {
             return <http:InternalServerError>{body: {message: customErr}};
         }
         return orgStructure;
+    }
+
+    # Fetch the employment history timeline for an employee.
+    #
+    # Returns every employment period held by the *person* behind the given employee ID
+    # (a rehire has more than one), the field-level changes derived from the audit trail,
+    # and the approved promotions from HRIS attached to the period they fall in.
+    #
+    # + employeeId - Employee ID
+    # + return - History timeline, or an error response
+    resource function get employees/[string employeeId]/history(http:RequestContext ctx)
+        returns EmployeeHistoryResponse|http:InternalServerError|http:NotFound|http:Forbidden {
+
+        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERROR_USER_INFORMATION_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        boolean hasAdminAccess = authorization:checkPermissions(
+                [authorization:authorizedRoles.ADMIN_ROLE], userInfo.groups);
+
+        // Authorization compares *people*, not employee IDs. A rehired person holds several
+        // employee IDs against one personal_info row (e.g. intern "IN 0456" then permanent
+        // "EP 10006"), so comparing the caller's employee ID against the requested one would
+        // deny them their own earlier employment. Admins bypass the check entirely.
+        if !hasAdminAccess {
+            int?|error callerPersonalInfoId = database:getPersonalInfoIdByWorkEmail(userInfo.email);
+            if callerPersonalInfoId is error {
+                string customErr = "Error occurred while resolving the invoker's employee record";
+                log:printError(customErr, callerPersonalInfoId, invokerEmail = userInfo.email);
+                return <http:InternalServerError>{body: {message: customErr}};
+            }
+
+            int?|error requestedPersonalInfoId = database:getPersonalInfoIdByEmployeeId(employeeId);
+            if requestedPersonalInfoId is error {
+                string customErr = string `Error occurred while resolving employee record for ID: ${employeeId}`;
+                log:printError(customErr, requestedPersonalInfoId, employeeId = employeeId);
+                return <http:InternalServerError>{body: {message: customErr}};
+            }
+
+            if requestedPersonalInfoId is () {
+                string customErr = "Employee information not found";
+                log:printWarn(customErr, employeeId = employeeId);
+                return <http:NotFound>{body: {message: customErr}};
+            }
+
+            if callerPersonalInfoId is () || callerPersonalInfoId != requestedPersonalInfoId {
+                log:printWarn("User is not authorized to view this employee's history",
+                        invokerEmail = userInfo.email, employeeId = employeeId);
+                return <http:Forbidden>{
+                    body: {message: "You are not authorized to view this employee's history"}
+                };
+            }
+        }
+
+        database:EmploymentPeriod[]|error periods = database:getEmploymentPeriods(employeeId);
+        if periods is error {
+            string customErr = string `Error occurred while fetching employment periods for ID: ${employeeId}`;
+            log:printError(customErr, periods, employeeId = employeeId);
+            return <http:InternalServerError>{body: {message: customErr}};
+        }
+
+        if periods.length() == 0 {
+            string customErr = "Employee information not found";
+            log:printWarn(customErr, employeeId = employeeId);
+            return <http:NotFound>{body: {message: customErr}};
+        }
+
+        int[] employeePkIds = from database:EmploymentPeriod period in periods
+            select period.id;
+
+        database:AuditSnapshot[]|error snapshots = database:getAuditSnapshots(employeePkIds);
+        if snapshots is error {
+            string customErr = string `Error occurred while fetching audit history for ID: ${employeeId}`;
+            log:printError(customErr, snapshots, employeeId = employeeId);
+            return <http:InternalServerError>{body: {message: customErr}};
+        }
+
+        database:HistoryEvent[] events = database:buildHistoryEvents(snapshots);
+
+        // The HRIS promotion database is a second database. An outage there must degrade the
+        // timeline rather than break the employee's own profile page, so the failure is
+        // reported as a flag alongside an otherwise complete response.
+        boolean promotionsUnavailable = false;
+        promotion:PromotionRecord[] promotions = [];
+        string workEmail = periods[0].workEmail;
+        promotion:PromotionRecord[]|error fetchedPromotions = promotion:getApprovedPromotions(workEmail);
+        if fetchedPromotions is error {
+            promotionsUnavailable = true;
+            log:printError("Error occurred while fetching promotions from HRIS; returning history without them",
+                    fetchedPromotions, employeeId = employeeId);
+        } else {
+            promotions = fetchedPromotions;
+        }
+
+        EmploymentPeriodResponse[] periodResponses = assignPromotionsToPeriods(periods, promotions);
+
+        return {
+            periods: periodResponses,
+            events: projectHistoryEvents(events, hasAdminAccess),
+            promotionsUnavailable: promotionsUnavailable
+        };
     }
 }

--- a/apps/people-app/backend/types.bal
+++ b/apps/people-app/backend/types.bal
@@ -21,7 +21,7 @@ import ballerina/constraint;
 
 # One field-level change as returned to the client.
 #
-# `actionBy` is optional rather than required because the non-ADMIN projection strips it
+# `actionBy` is optional rather than required because the reduced projection strips it
 # server-side. The field is absent from the payload entirely for those callers rather than
 # blanked, so the client is never handed an actor it is not permitted to display.
 public type HistoryEventResponse record {|
@@ -35,10 +35,10 @@ public type HistoryEventResponse record {|
     string? currentValue;
     # When the change occurred
     string occurredOn;
-    # Who made the change. Omitted entirely for non-ADMIN callers.
+    # Who made the change. Omitted entirely under the reduced projection.
     string actionBy?;
     # True when the change was made by an automated process rather than a person.
-    # Always false for non-ADMIN callers, whose system events are dropped outright.
+    # Always false under the reduced projection, whose system events are dropped outright.
     boolean isSystem;
 |};
 

--- a/apps/people-app/backend/types.bal
+++ b/apps/people-app/backend/types.bal
@@ -29,6 +29,8 @@ public type HistoryEventResponse record {|
     int employeePkId;
     # Canonical field key (e.g. "team_id")
     string 'field;
+    # Audit table the change came from, so the client can group events by kind
+    string sourceTable;
     # Value before the change, if any
     string? previousValue;
     # Value after the change

--- a/apps/people-app/backend/types.bal
+++ b/apps/people-app/backend/types.bal
@@ -15,8 +15,64 @@
 // under the License.
 
 import people.database;
+import people.promotion;
 
 import ballerina/constraint;
+
+# One field-level change as returned to the client.
+#
+# `actionBy` is optional rather than required because the non-ADMIN projection strips it
+# server-side. The field is absent from the payload entirely for those callers rather than
+# blanked, so the client is never handed an actor it is not permitted to display.
+public type HistoryEventResponse record {|
+    # Employee table primary key this event belongs to
+    int employeePkId;
+    # Canonical field key (e.g. "team_id")
+    string 'field;
+    # Value before the change, if any
+    string? previousValue;
+    # Value after the change
+    string? currentValue;
+    # When the change occurred
+    string occurredOn;
+    # Who made the change. Omitted entirely for non-ADMIN callers.
+    string actionBy?;
+    # True when the change was made by an automated process rather than a person.
+    # Always false for non-ADMIN callers, whose system events are dropped outright.
+    boolean isSystem;
+|};
+
+# One employment period with the promotions that fall inside it.
+public type EmploymentPeriodResponse record {|
+    # Employee table primary key
+    int id;
+    # Employee ID (e.g. "EP 10006")
+    string? employeeId;
+    # Employment type name
+    string employmentType;
+    # Start date
+    string startDate;
+    # Final day of employment, if the period has ended
+    string? endDate;
+    # Work email
+    string workEmail;
+    # Employee ID of the prior linked employment, if any
+    string? continuousServiceRecord;
+    # Approved promotions that took effect during this period
+    promotion:PromotionRecord[] promotions;
+|};
+
+# Employee history timeline: employment periods, field-level changes, and promotions.
+public type EmployeeHistoryResponse record {|
+    # Employment periods for the person, newest first, each carrying its promotions
+    EmploymentPeriodResponse[] periods;
+    # Field-level change events, newest first, already filtered for the caller's privilege
+    HistoryEventResponse[] events;
+    # True when the HRIS promotion lookup failed. The rest of the response is still valid;
+    # the client should indicate that promotions could not be loaded rather than that there
+    # were none.
+    boolean promotionsUnavailable;
+|};
 
 // # Payload for adding a vehicle.
 type NewVehicle record {|

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -816,13 +816,24 @@ public isolated function assignPromotionsToPeriods(database:EmploymentPeriod[] p
 
     foreach promotion:PromotionRecord promotionRecord in promotions {
         int? targetIndex = ();
+        string? promotedDate = promotionRecord.promotedDate;
+
+        // A promotion with no recorded date cannot be placed by range. It is still a real
+        // promotion, so it attaches to the current (newest) period rather than being dropped —
+        // HRIS contains APPROVED promotions in ended cycles whose date was never populated.
+        if promotedDate is () {
+            if periods.length() > 0 {
+                bucketed[0].push(promotionRecord);
+            }
+            continue;
+        }
 
         // Exact containment first.
         foreach int index in 0 ..< periods.length() {
             database:EmploymentPeriod period = periods[index];
             string? endDate = period.endDate;
-            boolean startedBy = promotionRecord.promotedDate >= period.startDate;
-            boolean endedAfter = endDate is () || promotionRecord.promotedDate <= endDate;
+            boolean startedBy = promotedDate >= period.startDate;
+            boolean endedAfter = endDate is () || promotedDate <= endDate;
             if startedBy && endedAfter {
                 targetIndex = index;
                 break;
@@ -834,7 +845,7 @@ public isolated function assignPromotionsToPeriods(database:EmploymentPeriod[] p
         // the nearest earlier one.
         if targetIndex is () {
             foreach int index in 0 ..< periods.length() {
-                if periods[index].startDate <= promotionRecord.promotedDate {
+                if periods[index].startDate <= promotedDate {
                     targetIndex = index;
                     break;
                 }

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -816,47 +816,31 @@ public isolated function assignPromotionsToPeriods(database:EmploymentPeriod[] p
 
     foreach promotion:PromotionRecord promotionRecord in promotions {
         int? targetIndex = ();
-        string? promotedDate = promotionRecord.promotedDate;
+        string createdOn = promotionRecord.createdOn;
 
-        // A promotion with no recorded date cannot be placed by range. It is still a real
-        // promotion, so it attaches to the current (newest) period rather than being dropped —
-        // HRIS contains APPROVED promotions in ended cycles whose date was never populated.
-        if promotedDate is () {
-            if periods.length() > 0 {
-                bucketed[0].push(promotionRecord);
-            }
-            continue;
-        }
-
-        // Exact containment first.
+        // A promotion request is raised while the employee is employed, so its created date
+        // always falls inside exactly one employment period. That containment is what
+        // attributes the promotion to the right employment — the promoted date is not used
+        // here, since HRIS frequently leaves it unpopulated.
         foreach int index in 0 ..< periods.length() {
             database:EmploymentPeriod period = periods[index];
             string? endDate = period.endDate;
-            boolean startedBy = promotedDate >= period.startDate;
-            boolean endedAfter = endDate is () || promotedDate <= endDate;
+            boolean startedBy = createdOn >= period.startDate;
+            boolean endedAfter = endDate is () || createdOn <= endDate;
             if startedBy && endedAfter {
                 targetIndex = index;
                 break;
             }
         }
 
-        // No range contains it: fall back to the nearest period that began before it. Periods
-        // arrive newest first, so the first period starting on or before the promoted date is
-        // the nearest earlier one.
-        if targetIndex is () {
-            foreach int index in 0 ..< periods.length() {
-                if periods[index].startDate <= promotedDate {
-                    targetIndex = index;
-                    break;
-                }
-            }
-        }
-
         if targetIndex is int {
             bucketed[targetIndex].push(promotionRecord);
         } else {
-            log:printWarn("Promotion predates every employment period; omitted from the timeline",
-                    promotedDate = promotionRecord.promotedDate, cycleName = promotionRecord.cycleName);
+            // No period contains it. This should not happen for well-formed data; it means the
+            // promotion's created date falls outside every employment period, which points at
+            // bad data rather than a timeline that needs a fallback.
+            log:printWarn("Promotion created date falls outside every employment period; omitted",
+                    createdOn = createdOn, cycleName = promotionRecord.cycleName);
         }
     }
 

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License. 
 import people.database;
+import people.promotion;
 
 import ballerina/data.csv;
 import ballerina/http;
@@ -741,4 +742,119 @@ public isolated function parseCsvBytes(byte[] fileBytes) returns BulkEmployeeCsv
         return error("CSV must contain a header row and at least one data row");
     }
     return rows;
+}
+
+# Reduce history events to what the calling privilege level is permitted to receive.
+#
+# The filtering happens here, on the server, and never on the client. An event the caller may
+# not see is absent from the payload rather than flagged for the client to hide, so the data
+# is not merely unrendered but never transmitted.
+#
+# For a non-ADMIN caller:
+# - `actionBy` is omitted from every event: an employee sees *that* their team changed, not
+#   which HR administrator changed it.
+# - Events made by system actors are dropped: migrations and scheduled jobs are operational
+#   noise that would read as unexplained changes to their own record.
+#
+# Leaver events (employee_status transitions and resignation reason) are returned in BOTH
+# projections. This is deliberate: the employee already knows they are leaving, and hiding the
+# transition would leave an unexplained gap at the end of their own timeline.
+#
+# + events - Derived history events, newest first
+# + hasAdminAccess - True when the caller holds the ADMIN role
+# + return - Events the caller is permitted to receive, newest first
+public isolated function projectHistoryEvents(database:HistoryEvent[] events, boolean hasAdminAccess)
+        returns HistoryEventResponse[] {
+
+    if hasAdminAccess {
+        return from database:HistoryEvent event in events
+            select {
+                employeePkId: event.employeePkId,
+                'field: event.'field,
+                previousValue: event.previousValue,
+                currentValue: event.currentValue,
+                occurredOn: event.occurredOn,
+                actionBy: event.actionBy,
+                isSystem: event.isSystem
+            };
+    }
+
+    return from database:HistoryEvent event in events
+        where !event.isSystem
+        select {
+            employeePkId: event.employeePkId,
+            'field: event.'field,
+            previousValue: event.previousValue,
+            currentValue: event.currentValue,
+            occurredOn: event.occurredOn,
+            isSystem: false
+        };
+}
+
+# Attach each promotion to the employment period it took effect during.
+#
+# A promotion belongs to the period whose startDate..endDate range contains its promotedDate.
+# An open period (no endDate) extends to the present.
+#
+# A promotion that falls in no range is attached to the nearest *earlier* period rather than
+# dropped, because the HRIS promoted date and the employment start date are maintained in two
+# different systems and disagree at the edges. Losing a real promotion is worse than showing it
+# one period early. A promotion earlier than every period has no earlier period to fall back on
+# and is left unattached.
+#
+# + periods - Employment periods for the person, newest first
+# + promotions - Approved promotions for the person
+# + return - Periods in their original order, each carrying its promotions
+public isolated function assignPromotionsToPeriods(database:EmploymentPeriod[] periods,
+        promotion:PromotionRecord[] promotions) returns EmploymentPeriodResponse[] {
+
+    promotion:PromotionRecord[][] bucketed = from database:EmploymentPeriod _ in periods
+        select [];
+
+    foreach promotion:PromotionRecord promotionRecord in promotions {
+        int? targetIndex = ();
+
+        // Exact containment first.
+        foreach int index in 0 ..< periods.length() {
+            database:EmploymentPeriod period = periods[index];
+            string? endDate = period.endDate;
+            boolean startedBy = promotionRecord.promotedDate >= period.startDate;
+            boolean endedAfter = endDate is () || promotionRecord.promotedDate <= endDate;
+            if startedBy && endedAfter {
+                targetIndex = index;
+                break;
+            }
+        }
+
+        // No range contains it: fall back to the nearest period that began before it. Periods
+        // arrive newest first, so the first period starting on or before the promoted date is
+        // the nearest earlier one.
+        if targetIndex is () {
+            foreach int index in 0 ..< periods.length() {
+                if periods[index].startDate <= promotionRecord.promotedDate {
+                    targetIndex = index;
+                    break;
+                }
+            }
+        }
+
+        if targetIndex is int {
+            bucketed[targetIndex].push(promotionRecord);
+        } else {
+            log:printWarn("Promotion predates every employment period; omitted from the timeline",
+                    promotedDate = promotionRecord.promotedDate, cycleName = promotionRecord.cycleName);
+        }
+    }
+
+    return from int index in 0 ..< periods.length()
+        select {
+            id: periods[index].id,
+            employeeId: periods[index].employeeId,
+            employmentType: periods[index].employmentType,
+            startDate: periods[index].startDate,
+            endDate: periods[index].endDate,
+            workEmail: periods[index].workEmail,
+            continuousServiceRecord: periods[index].continuousServiceRecord,
+            promotions: bucketed[index]
+        };
 }

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -774,6 +774,7 @@ public isolated function projectHistoryEvents(database:HistoryEvent[] events, bo
             select {
                 employeePkId: event.employeePkId,
                 'field: event.'field,
+                sourceTable: event.sourceTable,
                 previousValue: event.previousValue,
                 currentValue: event.currentValue,
                 occurredOn: event.occurredOn,
@@ -787,6 +788,7 @@ public isolated function projectHistoryEvents(database:HistoryEvent[] events, bo
         select {
             employeePkId: event.employeePkId,
             'field: event.'field,
+            sourceTable: event.sourceTable,
             previousValue: event.previousValue,
             currentValue: event.currentValue,
             occurredOn: event.occurredOn,

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -750,7 +750,10 @@ public isolated function parseCsvBytes(byte[] fileBytes) returns BulkEmployeeCsv
 # not see is absent from the payload rather than flagged for the client to hide, so the data
 # is not merely unrendered but never transmitted.
 #
-# For a non-ADMIN caller:
+# The full projection is granted to ADMINs and to a lead viewing their own subordinate; the
+# reduced projection applies to someone viewing their own record.
+#
+# Under the reduced projection:
 # - `actionBy` is omitted from every event: an employee sees *that* their team changed, not
 #   which HR administrator changed it.
 # - Events made by system actors are dropped: migrations and scheduled jobs are operational
@@ -761,12 +764,12 @@ public isolated function parseCsvBytes(byte[] fileBytes) returns BulkEmployeeCsv
 # transition would leave an unexplained gap at the end of their own timeline.
 #
 # + events - Derived history events, newest first
-# + hasAdminAccess - True when the caller holds the ADMIN role
+# + hasFullProjection - True when the caller may see attribution and system rows
 # + return - Events the caller is permitted to receive, newest first
-public isolated function projectHistoryEvents(database:HistoryEvent[] events, boolean hasAdminAccess)
+public isolated function projectHistoryEvents(database:HistoryEvent[] events, boolean hasFullProjection)
         returns HistoryEventResponse[] {
 
-    if hasAdminAccess {
+    if hasFullProjection {
         return from database:HistoryEvent event in events
             select {
                 employeePkId: event.employeePkId,

--- a/apps/people-app/backend/utils.bal
+++ b/apps/people-app/backend/utils.bal
@@ -794,16 +794,16 @@ public isolated function projectHistoryEvents(database:HistoryEvent[] events, bo
         };
 }
 
-# Attach each promotion to the employment period it took effect during.
+# Attach each promotion to the employment period it was raised during.
 #
-# A promotion belongs to the period whose startDate..endDate range contains its promotedDate.
-# An open period (no endDate) extends to the present.
+# A promotion belongs to the period whose startDate..endDate range contains its `createdOn`.
+# An open period (no endDate) extends to the present. The promoted date is deliberately not
+# used: HRIS frequently leaves it null, whereas a request is always raised while the employee
+# is employed, so its created date falls inside exactly one period.
 #
-# A promotion that falls in no range is attached to the nearest *earlier* period rather than
-# dropped, because the HRIS promoted date and the employment start date are maintained in two
-# different systems and disagree at the edges. Losing a real promotion is worse than showing it
-# one period early. A promotion earlier than every period has no earlier period to fall back on
-# and is left unattached.
+# A promotion matching no period is logged and omitted rather than reassigned. That should not
+# happen for well-formed data — it means the created date falls outside every employment
+# period, which points at bad data rather than a case needing a fallback.
 #
 # + periods - Employment periods for the person, newest first
 # + promotions - Approved promotions for the person

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -575,6 +575,25 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [employeeId, dispatch]);
 
+  // Declared above the early returns: hooks must run in the same order on every
+  // render, and the loading/failed branches below return before this point.
+  const counts = useMemo(() => {
+    const tally: Record<HistoryCategory, number> = {
+      employment: 0,
+      personal: 0,
+      promotion: 0,
+    };
+    (history?.events ?? []).forEach((event) => {
+      if (event.isSystem) return;
+      if (event.sourceTable === "personal_info_audit") tally.personal += 1;
+      else tally.employment += 1;
+    });
+    (history?.periods ?? []).forEach((period) => {
+      tally.promotion += period.promotions.length;
+    });
+    return tally;
+  }, [history]);
+
   if (state === State.loading || state === State.idle) {
     return (
       <Stack alignItems="center" justifyContent="center" spacing={1.5} sx={{ py: 5 }}>
@@ -601,23 +620,6 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
 
   // How many rows each category would contribute, so a category with nothing in
   // it can be hidden rather than offered as an empty filter.
-  const counts = useMemo(() => {
-    const tally: Record<HistoryCategory, number> = {
-      employment: 0,
-      personal: 0,
-      promotion: 0,
-    };
-    events.forEach((event) => {
-      if (event.isSystem) return;
-      if (event.sourceTable === "personal_info_audit") tally.personal += 1;
-      else tally.employment += 1;
-    });
-    periods.forEach((period) => {
-      tally.promotion += period.promotions.length;
-    });
-    return tally;
-  }, [events, periods]);
-
   const available = CATEGORY_ORDER.filter((category) => counts[category] > 0);
 
   if (periods.length === 0 && events.length === 0) {

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -350,11 +350,15 @@ const PeriodSection = ({
   const visibleRows = rows.filter((row) => !row.isSystem);
   const systemCount = rows.length - visibleRows.length;
 
+  // continuousServiceRecord holds the linked period's employee_id string
+  // (see getEmploymentPeriodsQuery: `csr.employee_id AS continuousServiceRecord`),
+  // not the linked period's numeric `id` — a period without an employeeId can
+  // never be a link target.
   const linkedPeriod = period.continuousServiceRecord
-    ? periods.find((p) => String(p.id) === period.continuousServiceRecord)
+    ? periods.find((p) => p.employeeId === period.continuousServiceRecord)
     : undefined;
   const linkedLabel = linkedPeriod
-    ? `${linkedPeriod.employmentType} · ${linkedPeriod.employeeId ?? linkedPeriod.id}`
+    ? `${linkedPeriod.employmentType} · ${linkedPeriod.employeeId}`
     : period.continuousServiceRecord;
 
   return (

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -81,6 +81,8 @@ const FIELD_LABELS: Record<string, string> = {
   postal_code: "Postal Code",
   country: "Country",
   nationality: "Nationality",
+  // employee_additional_managers_audit
+  additional_manager: "Additional Manager",
 };
 
 // Timeline filter categories. Relocations are deliberately absent: they are links
@@ -198,6 +200,9 @@ const buildRows = (
         isPromo: false,
         isJoin: false,
         isSystem: event.isSystem,
+        // Additional-manager rows come from their own audit table but read as an
+        // employment change, so they sit under Employment rather than earning a
+        // category with a single field in it.
         category:
           event.sourceTable === "personal_info_audit"
             ? "personal"

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { useEffect, useMemo } from "react";
+import { Fragment, useEffect, useMemo } from "react";
 import { format } from "date-fns/format";
 import { isValid } from "date-fns/isValid";
 import { parseISO } from "date-fns/parseISO";
@@ -379,30 +379,65 @@ const EventRow = ({ row }: { row: TimelineRow }) => {
   );
 };
 
+// Bridges the gap between two employment periods joined by a relocation, so the
+// link is drawn rather than described. Rendered above the period that carries the
+// continuousServiceRecord, spanning down from the one before it.
+const RelocationConnector = ({ label }: { label: string }) => {
+  const theme = useTheme();
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        py: 1.25,
+        pl: 1.5,
+        // The dashed rule sits on the same x as the event spine, so the eye
+        // follows one continuous vertical through the join.
+        "&::before": {
+          content: '""',
+          position: "absolute",
+          left: 15,
+          top: 0,
+          bottom: 0,
+          width: "1px",
+          backgroundImage: `repeating-linear-gradient(to bottom, ${theme.palette.text.disabled} 0 3px, transparent 3px 7px)`,
+        },
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={0.75}
+        sx={{
+          ml: 2.75,
+          px: 1.125,
+          py: 0.375,
+          borderRadius: 5,
+          backgroundColor: theme.palette.action.hover,
+          color: "text.secondary",
+        }}
+      >
+        <LinkOutlinedIcon sx={{ fontSize: 13 }} />
+        <Typography variant="caption" sx={{ fontWeight: 600 }}>
+          {label}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+};
+
 const PeriodSection = ({
   period,
   events,
-  periods,
 }: {
   period: EmploymentPeriod;
   events: HistoryEvent[];
-  periods: EmploymentPeriod[];
 }) => {
   const theme = useTheme();
   const rows = useMemo(() => buildRows(period, events), [period, events]);
   const visibleRows = rows.filter((row) => !row.isSystem);
   const systemCount = rows.length - visibleRows.length;
-
-  // continuousServiceRecord holds the linked period's employee_id string
-  // (see getEmploymentPeriodsQuery: `csr.employee_id AS continuousServiceRecord`),
-  // not the linked period's numeric `id` — a period without an employeeId can
-  // never be a link target.
-  const linkedPeriod = period.continuousServiceRecord
-    ? periods.find((p) => p.employeeId === period.continuousServiceRecord)
-    : undefined;
-  const linkedLabel = linkedPeriod
-    ? `${linkedPeriod.employmentType} · ${linkedPeriod.employeeId}`
-    : period.continuousServiceRecord;
 
   return (
     <Box sx={{ mb: 3.75 }}>
@@ -444,19 +479,6 @@ const PeriodSection = ({
         </Typography>
       </Stack>
 
-      {period.continuousServiceRecord && (
-        <Stack
-          direction="row"
-          alignItems="center"
-          spacing={0.75}
-          sx={{ color: "text.secondary", fontSize: 12, pt: 0.875, pb: 0.375, pl: 1.875 }}
-        >
-          <LinkOutlinedIcon sx={{ fontSize: 14 }} />
-          <Typography variant="caption" sx={{ color: "text.secondary" }}>
-            Relocation — linked to {linkedLabel}
-          </Typography>
-        </Stack>
-      )}
 
       <Box sx={{ position: "relative" }}>
         {visibleRows.map((row) => (
@@ -546,14 +568,23 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
         </Box>
       )}
 
-      {sortedPeriods.map((period) => (
-        <PeriodSection
-          key={period.id}
-          period={period}
-          events={events}
-          periods={periods}
-        />
-      ))}
+      {sortedPeriods.map((period, index) => {
+        // A period links backwards to the one it relocated from. Draw the
+        // connector only when that target is the period directly below it, so
+        // the line always spans a real adjacency rather than jumping a gap.
+        const previous = sortedPeriods[index + 1];
+        const linksToPrevious =
+          period.continuousServiceRecord !== null &&
+          previous !== undefined &&
+          previous.employeeId === period.continuousServiceRecord;
+
+        return (
+          <Fragment key={period.id}>
+            <PeriodSection period={period} events={events} />
+            {linksToPrevious && <RelocationConnector label="Relocation" />}
+          </Fragment>
+        );
+      })}
     </Box>
   );
 }

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -38,6 +38,7 @@ import {
   EmploymentPeriod,
   fetchEmployeeHistory,
   HistoryEvent,
+  resetEmployeeHistory,
   PromotionRecord,
 } from "@slices/employeeSlice/employeeHistory";
 
@@ -606,6 +607,11 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
 
   useEffect(() => {
     if (employeeId) dispatch(fetchEmployeeHistory(employeeId));
+    // Cleared on unmount so the global slice does not hand the next employee's
+    // section a previous timeline before its own fetch resolves.
+    return () => {
+      dispatch(resetEmployeeHistory());
+    };
     // Fetch once when this component mounts (i.e. on first expand by the parent);
     // do not add `state` here or every expand/collapse would re-trigger it.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -453,7 +453,7 @@ const PeriodSection = ({
         >
           <LinkOutlinedIcon sx={{ fontSize: 14 }} />
           <Typography variant="caption" sx={{ color: "text.secondary" }}>
-            Continuous service — linked to {linkedLabel}
+            Relocation — linked to {linkedLabel}
           </Typography>
         </Stack>
       )}

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -90,8 +90,13 @@ const statusChipColors = (theme: Theme, status: string) => {
 // promotion.
 interface TimelineRow {
   key: string;
-  // Nullable for promotions whose promoted date was never recorded in HRIS.
+  // What the date column displays. Nullable for promotions whose promoted date
+  // was never recorded in HRIS — those show their cycle name instead.
   date: string | null;
+  // What the row is ordered by, kept separate from what it displays. For a
+  // promotion this is its created date, which is always present even when the
+  // promoted date is not.
+  sortKey: string;
   isPromo: boolean;
   isJoin: boolean;
   isSystem: boolean;
@@ -111,6 +116,7 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
       rows.push({
         key: `event-${period.id}-${index}`,
         date: event.occurredOn,
+        sortKey: event.occurredOn,
         isPromo: false,
         isJoin: false,
         isSystem: event.isSystem,
@@ -125,6 +131,9 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
     rows.push({
       key: `promo-${period.id}-${index}`,
       date: promotion.promotedDate,
+      // Ordered by when the request was raised, not by the promoted date —
+      // the latter is frequently null in HRIS.
+      sortKey: promotion.createdOn,
       isPromo: true,
       isJoin: false,
       isSystem: false,
@@ -135,15 +144,12 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
     });
   });
 
-  // Newest first. A row with no recorded date (a promotion whose promoted date
-  // was never populated in HRIS) sorts to the top rather than being compared
-  // against a string, since it cannot be placed chronologically.
-  rows.sort((a, b) => {
-    if (a.date === b.date) return 0;
-    if (!a.date) return -1;
-    if (!b.date) return 1;
-    return a.date < b.date ? 1 : -1;
-  });
+  // Newest first, ordered by sortKey rather than the displayed date so a
+  // promotion sits at the point its request was raised even when it displays
+  // a cycle name instead of a date.
+  rows.sort((a, b) =>
+    a.sortKey < b.sortKey ? 1 : a.sortKey > b.sortKey ? -1 : 0,
+  );
 
   // The diff engine never emits a change event for the record that created
   // the employment row (an INSERT is a baseline, not a change), so "Joined"
@@ -151,6 +157,7 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
   rows.push({
     key: `join-${period.id}`,
     date: period.startDate,
+    sortKey: period.startDate,
     isPromo: false,
     isJoin: true,
     isSystem: false,

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -316,6 +316,10 @@ const EventRow = ({ row }: { row: TimelineRow }) => {
             )}
           </>
         ) : (
+          /* Three distinct shapes, not one: a value set for the first time, a
+             value changed, and a value removed. Rendering a removal as
+             "87 →" with nothing after the arrow reads as a bug rather than
+             as a deliberate clearing. */
           <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
             {row.previousValue !== null && (
               <>
@@ -328,10 +332,24 @@ const EventRow = ({ row }: { row: TimelineRow }) => {
                 >
                   {row.previousValue}
                 </Typography>
-                <Typography sx={{ color: "text.disabled" }}>{"→"}</Typography>
+                {row.currentValue !== null && (
+                  <Typography sx={{ color: "text.disabled" }}>{"→"}</Typography>
+                )}
               </>
             )}
-            {showStatusChip ? (
+            {row.currentValue === null ? (
+              <Chip
+                size="small"
+                label="Removed"
+                sx={{
+                  height: 20,
+                  fontWeight: 600,
+                  fontSize: 11,
+                  color: theme.palette.text.secondary,
+                  backgroundColor: theme.palette.action.hover,
+                }}
+              />
+            ) : showStatusChip ? (
               <Chip
                 size="small"
                 label={row.currentValue}
@@ -339,7 +357,7 @@ const EventRow = ({ row }: { row: TimelineRow }) => {
                   height: 20,
                   fontWeight: 600,
                   fontSize: 11,
-                  ...statusChipColors(theme, row.currentValue ?? ""),
+                  ...statusChipColors(theme, row.currentValue),
                 }}
               />
             ) : (

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Fragment, useEffect, useMemo } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { format } from "date-fns/format";
 import { isValid } from "date-fns/isValid";
 import { parseISO } from "date-fns/parseISO";
@@ -54,7 +54,41 @@ const FIELD_LABELS: Record<string, string> = {
   probation_end_date: "Probation End Date",
   agreement_end_date: "Agreement End Date",
   start_date: "Start Date",
+  // personal_info fields
+  nic_or_passport: "NIC / Passport",
+  first_name: "First Name",
+  last_name: "Last Name",
+  title: "Title",
+  dob: "Date of Birth",
+  gender: "Gender",
+  personal_email: "Personal Email",
+  personal_phone: "Personal Phone",
+  resident_number: "Resident Number",
+  address_line_1: "Address Line 1",
+  address_line_2: "Address Line 2",
+  city: "City",
+  state_or_province: "State / Province",
+  postal_code: "Postal Code",
+  country: "Country",
+  nationality: "Nationality",
 };
+
+// Timeline filter categories. Relocations are deliberately absent: they are links
+// between employment periods rather than events, so filtering to them alone would
+// leave connectors with nothing between them.
+type HistoryCategory = "employment" | "personal" | "promotion";
+
+const CATEGORY_LABELS: Record<HistoryCategory, string> = {
+  employment: "Employment",
+  personal: "Personal Info",
+  promotion: "Promotions",
+};
+
+const CATEGORY_ORDER: HistoryCategory[] = [
+  "employment",
+  "personal",
+  "promotion",
+];
 
 const fieldLabel = (field: string): string =>
   FIELD_LABELS[field] ??
@@ -100,6 +134,10 @@ interface TimelineRow {
   isPromo: boolean;
   isJoin: boolean;
   isSystem: boolean;
+  // Which filter category this row belongs to. A "Joined" row has none: it is
+  // structural, so it stays visible whatever filter is applied — otherwise a
+  // filtered period would lose the row that anchors it.
+  category: HistoryCategory | null;
   field: string;
   previousValue: string | null;
   currentValue: string | null;
@@ -120,6 +158,10 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
         isPromo: false,
         isJoin: false,
         isSystem: event.isSystem,
+        category:
+          event.sourceTable === "personal_info_audit"
+            ? "personal"
+            : "employment",
         field: event.field,
         previousValue: event.previousValue,
         currentValue: event.currentValue,
@@ -137,6 +179,7 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
       isPromo: true,
       isJoin: false,
       isSystem: false,
+      category: "promotion",
       field: "Promotion",
       previousValue: promotion.currentJobBand,
       currentValue: promotion.nextJobBand,
@@ -161,6 +204,7 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
     isPromo: false,
     isJoin: true,
     isSystem: false,
+    category: null,
     field: "Joined",
     previousValue: null,
     currentValue: period.employmentType,
@@ -430,14 +474,22 @@ const RelocationConnector = ({ label }: { label: string }) => {
 const PeriodSection = ({
   period,
   events,
+  selected,
 }: {
   period: EmploymentPeriod;
   events: HistoryEvent[];
+  selected: Set<HistoryCategory>;
 }) => {
   const theme = useTheme();
   const rows = useMemo(() => buildRows(period, events), [period, events]);
-  const visibleRows = rows.filter((row) => !row.isSystem);
-  const systemCount = rows.length - visibleRows.length;
+  // A row with no category is structural ("Joined") and survives every filter,
+  // so a filtered period keeps the row that anchors it rather than collapsing
+  // to an empty block.
+  const visibleRows = rows.filter(
+    (row) =>
+      !row.isSystem && (row.category === null || selected.has(row.category)),
+  );
+  const systemCount = rows.filter((row) => row.isSystem).length;
 
   return (
     <Box sx={{ mb: 3.75 }}>
@@ -499,6 +551,23 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
   const dispatch = useAppDispatch();
   const { state, history, errorMessage } = useAppSelector((s) => s.employeeHistory);
 
+  // Deliberately not persisted: a filter set days ago and forgotten is how a
+  // reader concludes data is missing. Every open starts showing everything.
+  const [selected, setSelected] = useState<Set<HistoryCategory>>(
+    () => new Set(CATEGORY_ORDER),
+  );
+
+  const toggle = (category: HistoryCategory) =>
+    setSelected((current) => {
+      const next = new Set(current);
+      // Never allow an empty selection — deselecting the last active category
+      // would show a timeline of nothing, which reads as broken rather than
+      // filtered.
+      if (next.has(category) && next.size > 1) next.delete(category);
+      else next.add(category);
+      return next;
+    });
+
   useEffect(() => {
     if (employeeId) dispatch(fetchEmployeeHistory(employeeId));
     // Fetch once when this component mounts (i.e. on first expand by the parent);
@@ -529,6 +598,27 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
 
   const periods = history?.periods ?? [];
   const events = history?.events ?? [];
+
+  // How many rows each category would contribute, so a category with nothing in
+  // it can be hidden rather than offered as an empty filter.
+  const counts = useMemo(() => {
+    const tally: Record<HistoryCategory, number> = {
+      employment: 0,
+      personal: 0,
+      promotion: 0,
+    };
+    events.forEach((event) => {
+      if (event.isSystem) return;
+      if (event.sourceTable === "personal_info_audit") tally.personal += 1;
+      else tally.employment += 1;
+    });
+    periods.forEach((period) => {
+      tally.promotion += period.promotions.length;
+    });
+    return tally;
+  }, [events, periods]);
+
+  const available = CATEGORY_ORDER.filter((category) => counts[category] > 0);
 
   if (periods.length === 0 && events.length === 0) {
     return (
@@ -568,6 +658,38 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
         </Box>
       )}
 
+      {available.length > 1 && (
+        <Stack
+          direction="row"
+          spacing={1}
+          flexWrap="wrap"
+          useFlexGap
+          sx={{ mb: 2.5 }}
+        >
+          {available.map((category) => {
+            const isOn = selected.has(category);
+            return (
+              <Chip
+                key={category}
+                size="small"
+                clickable
+                onClick={() => toggle(category)}
+                label={`${CATEGORY_LABELS[category]} ${counts[category]}`}
+                variant={isOn ? "filled" : "outlined"}
+                sx={{
+                  height: 26,
+                  fontWeight: 600,
+                  fontSize: 12,
+                  ...(isOn
+                    ? {}
+                    : { color: "text.secondary", borderColor: "divider" }),
+                }}
+              />
+            );
+          })}
+        </Stack>
+      )}
+
       {sortedPeriods.map((period, index) => {
         // A period links backwards to the one it relocated from. Draw the
         // connector only when that target is the period directly below it, so
@@ -580,7 +702,11 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
 
         return (
           <Fragment key={period.id}>
-            <PeriodSection period={period} events={events} />
+            <PeriodSection
+              period={period}
+              events={events}
+              selected={selected}
+            />
             {linksToPrevious && <RelocationConnector label="Relocation" />}
           </Fragment>
         );

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -1,0 +1,512 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useMemo } from "react";
+import { format } from "date-fns/format";
+import { isValid } from "date-fns/isValid";
+import { parseISO } from "date-fns/parseISO";
+import { alpha, Box, Chip, Stack, Typography, useTheme } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
+import CircularProgress from "@mui/material/CircularProgress";
+import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
+import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
+import { State } from "@/types/types";
+import { useAppDispatch, useAppSelector } from "@slices/store";
+import {
+  EmploymentPeriod,
+  fetchEmployeeHistory,
+  HistoryEvent,
+  PromotionRecord,
+} from "@slices/employeeSlice/employeeHistory";
+
+// Raw audit column names -> reader-facing labels. Keep in sync with
+// TRACKED_EMPLOYEE_FIELDS in backend/modules/database/history.bal.
+const FIELD_LABELS: Record<string, string> = {
+  business_unit_id: "Business Unit",
+  team_id: "Team",
+  sub_team_id: "Sub-team",
+  unit_id: "Unit",
+  designation_id: "Designation",
+  employment_type_id: "Employment Type",
+  company_id: "Company",
+  office_id: "Office",
+  manager_email: "Reporting to",
+  employee_status: "Employee Status",
+  work_location: "Work Location",
+  job_role: "Job Role",
+  secondary_job_title: "Secondary Job Title",
+  external_designation: "External Designation",
+  house_id: "House",
+  epf: "EPF Number",
+  probation_end_date: "Probation End Date",
+  agreement_end_date: "Agreement End Date",
+  start_date: "Start Date",
+};
+
+const fieldLabel = (field: string): string =>
+  FIELD_LABELS[field] ??
+  field
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+// occurredOn/promotedDate arrive as raw SQL date/timestamp strings (the audit
+// tables use TIMESTAMP columns), so a strict yyyy-MM-dd parser would blank
+// them out. Parse leniently and format for display only.
+const formatEventDate = (value: string | null | undefined): string => {
+  if (!value) return "-";
+  const parsed = parseISO(value.includes(" ") ? value.replace(" ", "T") : value);
+  return isValid(parsed) ? format(parsed, "d MMM yyyy") : value;
+};
+
+const statusChipColors = (theme: Theme, status: string) => {
+  const normalized = status.trim().toLowerCase();
+  const mainColor =
+    normalized === "marked leaver"
+      ? theme.palette.warning.main
+      : normalized === "left"
+        ? theme.palette.error.main
+        : theme.palette.success.main;
+  return {
+    color: mainColor,
+    backgroundColor: alpha(mainColor, theme.palette.mode === "dark" ? 0.18 : 0.12),
+  };
+};
+
+// A single row rendered on the spine: either a field-level change, a
+// synthetic "Joined" row derived from the period's start date, or a
+// promotion.
+interface TimelineRow {
+  key: string;
+  date: string;
+  isPromo: boolean;
+  isJoin: boolean;
+  isSystem: boolean;
+  field: string;
+  previousValue: string | null;
+  currentValue: string | null;
+  actionBy?: string;
+  promotion?: PromotionRecord;
+}
+
+const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRow[] => {
+  const rows: TimelineRow[] = [];
+
+  events
+    .filter((event) => event.employeePkId === period.id)
+    .forEach((event, index) => {
+      rows.push({
+        key: `event-${period.id}-${index}`,
+        date: event.occurredOn,
+        isPromo: false,
+        isJoin: false,
+        isSystem: event.isSystem,
+        field: event.field,
+        previousValue: event.previousValue,
+        currentValue: event.currentValue,
+        actionBy: event.actionBy,
+      });
+    });
+
+  period.promotions.forEach((promotion, index) => {
+    rows.push({
+      key: `promo-${period.id}-${index}`,
+      date: promotion.promotedDate,
+      isPromo: true,
+      isJoin: false,
+      isSystem: false,
+      field: "Promotion",
+      previousValue: promotion.currentJobBand,
+      currentValue: promotion.nextJobBand,
+      promotion,
+    });
+  });
+
+  rows.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+  // The diff engine never emits a change event for the record that created
+  // the employment row (an INSERT is a baseline, not a change), so "Joined"
+  // is synthesized here from the period itself and always sits last.
+  rows.push({
+    key: `join-${period.id}`,
+    date: period.startDate,
+    isPromo: false,
+    isJoin: true,
+    isSystem: false,
+    field: "Joined",
+    previousValue: null,
+    currentValue: period.employmentType,
+  });
+
+  return rows;
+};
+
+const Dot = ({ isPromo, isJoin }: { isPromo: boolean; isJoin: boolean }) => (
+  <Box sx={{ position: "relative", width: 32, height: 15, flexShrink: 0 }}>
+    <Box
+      sx={(theme) => ({
+        position: "absolute",
+        left: isPromo ? 10 : 11,
+        top: isPromo ? 4 : 5,
+        width: isPromo ? 9 : 7,
+        height: isPromo ? 9 : 7,
+        borderRadius: "50%",
+        backgroundColor: isPromo
+          ? theme.palette.secondary.contrastText
+          : isJoin
+            ? theme.palette.text.secondary
+            : theme.palette.divider,
+        boxShadow: `0 0 0 3px ${theme.palette.background.paper}`,
+      })}
+    />
+  </Box>
+);
+
+const EventRow = ({ row }: { row: TimelineRow }) => {
+  const theme = useTheme();
+  const label = row.isJoin || row.isPromo ? row.field : fieldLabel(row.field);
+  const isStatusField = row.field === "employee_status";
+  const statusValue = (row.currentValue ?? "").trim().toLowerCase();
+  const showStatusChip =
+    isStatusField && (statusValue === "marked leaver" || statusValue === "left");
+
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        display: "grid",
+        gridTemplateColumns: "32px 96px 1fr",
+        alignItems: "baseline",
+        gap: "0 14px",
+        py: 1.125,
+        borderTop: `1px solid ${theme.palette.divider}`,
+        "&:first-of-type": { borderTop: "none" },
+      }}
+    >
+      <Dot isPromo={row.isPromo} isJoin={row.isJoin} />
+      <Typography
+        variant="caption"
+        sx={{
+          color: "text.secondary",
+          fontVariantNumeric: "tabular-nums",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {formatEventDate(row.date)}
+      </Typography>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            display: "block",
+            color: "text.secondary",
+            letterSpacing: "0.03em",
+            textTransform: "uppercase",
+            mb: 0.25,
+          }}
+        >
+          {label}
+        </Typography>
+
+        {row.isJoin ? (
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+            <Typography sx={{ fontWeight: 550 }}>{row.currentValue}</Typography>
+          </Stack>
+        ) : row.isPromo ? (
+          <>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+              <Typography
+                sx={{
+                  color: "text.secondary",
+                  textDecoration: "line-through",
+                  textDecorationColor: theme.palette.divider,
+                }}
+              >
+                {row.previousValue}
+              </Typography>
+              <Typography sx={{ color: "text.disabled" }}>{"→"}</Typography>
+              <Typography sx={{ fontWeight: 550 }}>{row.currentValue}</Typography>
+              <Chip
+                size="small"
+                label="Approved"
+                sx={{
+                  height: 20,
+                  fontWeight: 600,
+                  fontSize: 11,
+                  color: theme.palette.secondary.contrastText,
+                  backgroundColor: alpha(
+                    theme.palette.secondary.contrastText,
+                    theme.palette.mode === "dark" ? 0.18 : 0.12,
+                  ),
+                }}
+              />
+            </Stack>
+            {row.promotion && (
+              <Box
+                sx={{
+                  mt: 0.875,
+                  p: 1.25,
+                  border: `1px solid ${theme.palette.divider}`,
+                  borderRadius: 1.5,
+                  display: "flex",
+                  flexWrap: "wrap",
+                  columnGap: 2.25,
+                  rowGap: 0.5,
+                }}
+              >
+                {[
+                  ["Cycle", row.promotion.cycleName],
+                  ["Type", row.promotion.promotionType],
+                  ["Role", row.promotion.jobRole],
+                ].map(([dt, dd]) => (
+                  <Box key={dt} sx={{ display: "flex", gap: 0.75 }}>
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      {dt}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontWeight: 550,
+                        fontVariantNumeric: "tabular-nums",
+                        color: "text.primary",
+                      }}
+                    >
+                      {dd || "-"}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </>
+        ) : (
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+            {row.previousValue !== null && (
+              <>
+                <Typography
+                  sx={{
+                    color: "text.secondary",
+                    textDecoration: "line-through",
+                    textDecorationColor: theme.palette.divider,
+                  }}
+                >
+                  {row.previousValue}
+                </Typography>
+                <Typography sx={{ color: "text.disabled" }}>{"→"}</Typography>
+              </>
+            )}
+            {showStatusChip ? (
+              <Chip
+                size="small"
+                label={row.currentValue}
+                sx={{
+                  height: 20,
+                  fontWeight: 600,
+                  fontSize: 11,
+                  ...statusChipColors(theme, row.currentValue ?? ""),
+                }}
+              />
+            ) : (
+              <Typography sx={{ fontWeight: 550 }}>{row.currentValue}</Typography>
+            )}
+          </Stack>
+        )}
+
+        {row.actionBy && (
+          <Typography
+            variant="caption"
+            sx={{ display: "block", color: "text.disabled", mt: 0.375 }}
+          >
+            by {row.actionBy}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const PeriodSection = ({
+  period,
+  events,
+  periods,
+}: {
+  period: EmploymentPeriod;
+  events: HistoryEvent[];
+  periods: EmploymentPeriod[];
+}) => {
+  const theme = useTheme();
+  const rows = useMemo(() => buildRows(period, events), [period, events]);
+  const visibleRows = rows.filter((row) => !row.isSystem);
+  const systemCount = rows.length - visibleRows.length;
+
+  const linkedPeriod = period.continuousServiceRecord
+    ? periods.find((p) => String(p.id) === period.continuousServiceRecord)
+    : undefined;
+  const linkedLabel = linkedPeriod
+    ? `${linkedPeriod.employmentType} · ${linkedPeriod.employeeId ?? linkedPeriod.id}`
+    : period.continuousServiceRecord;
+
+  return (
+    <Box sx={{ mb: 3.75 }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={1.25}
+        flexWrap="wrap"
+        sx={{ pb: 1.125, borderBottom: `1px solid ${theme.palette.divider}`, mb: 0.5 }}
+      >
+        <Typography sx={{ fontWeight: 640, fontSize: 14.5 }}>
+          {period.employmentType}
+        </Typography>
+        {period.employeeId && (
+          <Typography
+            variant="caption"
+            sx={{
+              fontFamily:
+                'ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace',
+              color: "text.secondary",
+              backgroundColor: theme.palette.action.hover,
+              px: 0.75,
+              py: 0.125,
+              borderRadius: 0.5,
+            }}
+          >
+            {period.employeeId}
+          </Typography>
+        )}
+        <Typography
+          variant="caption"
+          sx={{
+            color: "text.secondary",
+            fontVariantNumeric: "tabular-nums",
+            ml: "auto",
+          }}
+        >
+          {formatEventDate(period.startDate)} — {period.endDate ? formatEventDate(period.endDate) : "present"}
+        </Typography>
+      </Stack>
+
+      {period.continuousServiceRecord && (
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={0.75}
+          sx={{ color: "text.secondary", fontSize: 12, pt: 0.875, pb: 0.375, pl: 1.875 }}
+        >
+          <LinkOutlinedIcon sx={{ fontSize: 14 }} />
+          <Typography variant="caption" sx={{ color: "text.secondary" }}>
+            Continuous service — linked to {linkedLabel}
+          </Typography>
+        </Stack>
+      )}
+
+      <Box sx={{ position: "relative" }}>
+        {visibleRows.map((row) => (
+          <EventRow key={row.key} row={row} />
+        ))}
+      </Box>
+
+      {systemCount > 0 && (
+        <Typography variant="caption" sx={{ color: "text.disabled", display: "block", mt: 0.75 }}>
+          SYSTEM · {systemCount} {systemCount === 1 ? "run" : "runs"} collapsed
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default function EmployeeHistory({ employeeId }: { employeeId: string }) {
+  const dispatch = useAppDispatch();
+  const { state, history, errorMessage } = useAppSelector((s) => s.employeeHistory);
+
+  useEffect(() => {
+    if (employeeId) dispatch(fetchEmployeeHistory(employeeId));
+    // Fetch once when this component mounts (i.e. on first expand by the parent);
+    // do not add `state` here or every expand/collapse would re-trigger it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [employeeId, dispatch]);
+
+  if (state === State.loading || state === State.idle) {
+    return (
+      <Stack alignItems="center" justifyContent="center" spacing={1.5} sx={{ py: 5 }}>
+        <CircularProgress size={28} />
+        <Typography variant="body2" color="text.secondary">
+          Loading history...
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (state === State.failed) {
+    return (
+      <Stack alignItems="center" justifyContent="center" spacing={1} sx={{ py: 5 }}>
+        <Typography variant="body2" color="error">
+          {errorMessage || "Failed to load employee history."}
+        </Typography>
+      </Stack>
+    );
+  }
+
+  const periods = history?.periods ?? [];
+  const events = history?.events ?? [];
+
+  if (periods.length === 0 && events.length === 0) {
+    return (
+      <Stack alignItems="center" justifyContent="center" spacing={1.5} sx={{ py: 5 }}>
+        <HistoryOutlinedIcon sx={{ fontSize: 32, color: "text.disabled" }} />
+        <Typography variant="body2" color="text.secondary">
+          No events recorded yet.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  const sortedPeriods = [...periods].sort((a, b) =>
+    a.startDate < b.startDate ? 1 : a.startDate > b.startDate ? -1 : 0,
+  );
+
+  return (
+    <Box>
+      {history?.promotionsUnavailable && (
+        <Box
+          sx={(theme) => ({
+            mb: 2.25,
+            px: 1.625,
+            py: 1.125,
+            borderLeft: `2px solid ${theme.palette.warning.main}`,
+            backgroundColor: alpha(
+              theme.palette.warning.main,
+              theme.palette.mode === "dark" ? 0.12 : 0.08,
+            ),
+            borderRadius: "0 6px 6px 0",
+          })}
+        >
+          <Typography variant="body2" color="text.secondary">
+            Promotion history is temporarily unavailable. The rest of the
+            timeline below is unaffected.
+          </Typography>
+        </Box>
+      )}
+
+      {sortedPeriods.map((period) => (
+        <PeriodSection
+          key={period.id}
+          period={period}
+          events={events}
+          periods={periods}
+        />
+      ))}
+    </Box>
+  );
+}

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -145,11 +145,38 @@ interface TimelineRow {
   promotion?: PromotionRecord;
 }
 
-const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRow[] => {
+// Personal information belongs to the person, not to one employment: the backend
+// stamps those rows with an anchor employment id, which is arbitrary. Attach them
+// to the period whose date range contains them instead — the same rule promotions
+// already follow — so they appear against the employment they happened during.
+const ownsPersonalEvent = (
+  period: EmploymentPeriod,
+  periods: EmploymentPeriod[],
+  occurredOn: string,
+): boolean => {
+  const containing = periods.find((candidate) => {
+    const startedBy = occurredOn >= candidate.startDate;
+    const endedAfter = candidate.endDate === null || occurredOn <= candidate.endDate;
+    return startedBy && endedAfter;
+  });
+  // Outside every range (a change made after the last employment ended, say):
+  // fall back to the most recent period so the event is never silently dropped.
+  return containing ? containing.id === period.id : periods[0]?.id === period.id;
+};
+
+const buildRows = (
+  period: EmploymentPeriod,
+  events: HistoryEvent[],
+  periods: EmploymentPeriod[],
+): TimelineRow[] => {
   const rows: TimelineRow[] = [];
 
   events
-    .filter((event) => event.employeePkId === period.id)
+    .filter((event) =>
+      event.sourceTable === "personal_info_audit"
+        ? ownsPersonalEvent(period, periods, event.occurredOn)
+        : event.employeePkId === period.id,
+    )
     .forEach((event, index) => {
       rows.push({
         key: `event-${period.id}-${index}`,
@@ -474,14 +501,19 @@ const RelocationConnector = ({ label }: { label: string }) => {
 const PeriodSection = ({
   period,
   events,
+  periods,
   selected,
 }: {
   period: EmploymentPeriod;
   events: HistoryEvent[];
+  periods: EmploymentPeriod[];
   selected: Set<HistoryCategory>;
 }) => {
   const theme = useTheme();
-  const rows = useMemo(() => buildRows(period, events), [period, events]);
+  const rows = useMemo(
+    () => buildRows(period, events, periods),
+    [period, events, periods],
+  );
   // A row with no category is structural ("Joined") and survives every filter,
   // so a filtered period keeps the row that anchors it rather than collapsing
   // to an empty block.
@@ -707,6 +739,7 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
             <PeriodSection
               period={period}
               events={events}
+              periods={sortedPeriods}
               selected={selected}
             />
             {linksToPrevious && <RelocationConnector label="Relocation" />}

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -213,7 +213,9 @@ const EventRow = ({ row }: { row: TimelineRow }) => {
           whiteSpace: "nowrap",
         }}
       >
-        {formatEventDate(row.date)}
+        {row.date
+          ? formatEventDate(row.date)
+          : (row.promotion?.cycleName ?? "-")}
       </Typography>
       <Box sx={{ minWidth: 0 }}>
         <Typography
@@ -275,11 +277,18 @@ const EventRow = ({ row }: { row: TimelineRow }) => {
                   rowGap: 0.5,
                 }}
               >
-                {[
-                  ["Cycle", row.promotion.cycleName],
-                  ["Type", row.promotion.promotionType],
-                  ["Role", row.promotion.jobRole],
-                ].map(([dt, dd]) => (
+                {(
+                  [
+                    // The cycle name stands in for the date when HRIS has no
+                    // promoted date, so it is only repeated here when a real
+                    // date occupies the date column.
+                    ...(row.date
+                      ? [["Cycle", row.promotion.cycleName]]
+                      : []),
+                    ["Type", row.promotion.promotionType],
+                    ["Role", row.promotion.jobRole],
+                  ] as [string, string][]
+                ).map(([dt, dd]) => (
                   <Box key={dt} sx={{ display: "flex", gap: 0.75 }}>
                     <Typography variant="caption" sx={{ color: "text.secondary" }}>
                       {dt}

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -662,6 +662,10 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
 
   // How many rows each category would contribute, so a category with nothing in
   // it can be hidden rather than offered as an empty filter.
+  // Categories with nothing in them are left out, but the row itself is shown
+  // whenever any history exists — including when that leaves a single category.
+  // Hiding it below two made the control appear and disappear between employees,
+  // which reads as a bug rather than as an absence of anything to filter.
   const available = CATEGORY_ORDER.filter((category) => counts[category] > 0);
   const totalCount = CATEGORY_ORDER.reduce((sum, c) => sum + counts[c], 0);
 
@@ -703,7 +707,7 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
         </Box>
       )}
 
-      {available.length > 1 && (
+      {available.length > 0 && (
         <Tabs
           value={view}
           onChange={(_, next: HistoryView) => setView(next)}

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -18,7 +18,16 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import { format } from "date-fns/format";
 import { isValid } from "date-fns/isValid";
 import { parseISO } from "date-fns/parseISO";
-import { alpha, Box, Chip, Stack, Typography, useTheme } from "@mui/material";
+import {
+  alpha,
+  Box,
+  Chip,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import type { Theme } from "@mui/material/styles";
 import CircularProgress from "@mui/material/CircularProgress";
 import HistoryOutlinedIcon from "@mui/icons-material/HistoryOutlined";
@@ -89,6 +98,9 @@ const CATEGORY_ORDER: HistoryCategory[] = [
   "personal",
   "promotion",
 ];
+
+// "all" is a view but not a category: it matches every row rather than tagging one.
+type HistoryView = HistoryCategory | "all";
 
 const fieldLabel = (field: string): string =>
   FIELD_LABELS[field] ??
@@ -502,12 +514,12 @@ const PeriodSection = ({
   period,
   events,
   periods,
-  selected,
+  view,
 }: {
   period: EmploymentPeriod;
   events: HistoryEvent[];
   periods: EmploymentPeriod[];
-  selected: Set<HistoryCategory>;
+  view: HistoryView;
 }) => {
   const theme = useTheme();
   const rows = useMemo(
@@ -519,7 +531,8 @@ const PeriodSection = ({
   // to an empty block.
   const visibleRows = rows.filter(
     (row) =>
-      !row.isSystem && (row.category === null || selected.has(row.category)),
+      !row.isSystem &&
+      (view === "all" || row.category === null || row.category === view),
   );
   const systemCount = rows.filter((row) => row.isSystem).length;
 
@@ -585,20 +598,11 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
 
   // Deliberately not persisted: a filter set days ago and forgotten is how a
   // reader concludes data is missing. Every open starts showing everything.
-  const [selected, setSelected] = useState<Set<HistoryCategory>>(
-    () => new Set(CATEGORY_ORDER),
-  );
-
-  const toggle = (category: HistoryCategory) =>
-    setSelected((current) => {
-      const next = new Set(current);
-      // Never allow an empty selection — deselecting the last active category
-      // would show a timeline of nothing, which reads as broken rather than
-      // filtered.
-      if (next.has(category) && next.size > 1) next.delete(category);
-      else next.add(category);
-      return next;
-    });
+  // One active view rather than a set of toggles: "which view of this timeline"
+  // is the question being answered, and it removes the awkward rule that the
+  // last active category cannot be deselected. Not persisted — a filter set days
+  // ago and forgotten is how a reader concludes data is missing.
+  const [view, setView] = useState<HistoryView>("all");
 
   useEffect(() => {
     if (employeeId) dispatch(fetchEmployeeHistory(employeeId));
@@ -653,6 +657,7 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
   // How many rows each category would contribute, so a category with nothing in
   // it can be hidden rather than offered as an empty filter.
   const available = CATEGORY_ORDER.filter((category) => counts[category] > 0);
+  const totalCount = CATEGORY_ORDER.reduce((sum, c) => sum + counts[c], 0);
 
   if (periods.length === 0 && events.length === 0) {
     return (
@@ -693,35 +698,58 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
       )}
 
       {available.length > 1 && (
-        <Stack
-          direction="row"
-          spacing={1}
-          flexWrap="wrap"
-          useFlexGap
-          sx={{ mb: 2.5 }}
+        <Tabs
+          value={view}
+          onChange={(_, next: HistoryView) => setView(next)}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{
+            minHeight: 0,
+            mb: 2.5,
+            borderBottom: 1,
+            borderColor: "divider",
+            "& .MuiTab-root": {
+              minHeight: 0,
+              minWidth: 0,
+              px: 0,
+              mr: 2.75,
+              py: 1,
+              fontSize: 13,
+              fontWeight: 600,
+              textTransform: "none",
+              color: "text.secondary",
+            },
+            "& .Mui-selected": { color: "text.primary" },
+          }}
         >
-          {available.map((category) => {
-            const isOn = selected.has(category);
-            return (
-              <Chip
-                key={category}
-                size="small"
-                clickable
-                onClick={() => toggle(category)}
-                label={`${CATEGORY_LABELS[category]} ${counts[category]}`}
-                variant={isOn ? "filled" : "outlined"}
-                sx={{
-                  height: 26,
-                  fontWeight: 600,
-                  fontSize: 12,
-                  ...(isOn
-                    ? {}
-                    : { color: "text.secondary", borderColor: "divider" }),
-                }}
-              />
-            );
-          })}
-        </Stack>
+          {(["all", ...available] as HistoryView[]).map((option) => (
+            <Tab
+              key={option}
+              value={option}
+              label={
+                <Stack direction="row" spacing={0.75} alignItems="center">
+                  <span>
+                    {option === "all" ? "All" : CATEGORY_LABELS[option]}
+                  </span>
+                  <Box
+                    component="span"
+                    sx={{
+                      fontSize: 11,
+                      fontWeight: 600,
+                      color: "text.disabled",
+                      backgroundColor: "action.hover",
+                      borderRadius: 4,
+                      px: 0.625,
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                  >
+                    {option === "all" ? totalCount : counts[option]}
+                  </Box>
+                </Stack>
+              }
+            />
+          ))}
+        </Tabs>
       )}
 
       {sortedPeriods.map((period, index) => {
@@ -740,7 +768,7 @@ export default function EmployeeHistory({ employeeId }: { employeeId: string }) 
               period={period}
               events={events}
               periods={sortedPeriods}
-              selected={selected}
+              view={view}
             />
             {linksToPrevious && <RelocationConnector label="Relocation" />}
           </Fragment>

--- a/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
+++ b/apps/people-app/webapp/src/component/employeeHistory/EmployeeHistory.tsx
@@ -90,7 +90,8 @@ const statusChipColors = (theme: Theme, status: string) => {
 // promotion.
 interface TimelineRow {
   key: string;
-  date: string;
+  // Nullable for promotions whose promoted date was never recorded in HRIS.
+  date: string | null;
   isPromo: boolean;
   isJoin: boolean;
   isSystem: boolean;
@@ -134,7 +135,15 @@ const buildRows = (period: EmploymentPeriod, events: HistoryEvent[]): TimelineRo
     });
   });
 
-  rows.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+  // Newest first. A row with no recorded date (a promotion whose promoted date
+  // was never populated in HRIS) sorts to the top rather than being compared
+  // against a string, since it cannot be placed chronologically.
+  rows.sort((a, b) => {
+    if (a.date === b.date) return 0;
+    if (!a.date) return -1;
+    if (!b.date) return 1;
+    return a.date < b.date ? 1 : -1;
+  });
 
   // The diff engine never emits a change event for the record that created
   // the employment row (an INSERT is a baseline, not a change), so "Joined"

--- a/apps/people-app/webapp/src/config/config.ts
+++ b/apps/people-app/webapp/src/config/config.ts
@@ -61,6 +61,8 @@ export const AppConfig = {
       SERVICE_BASE_URL + `/employees/${employeeId}/personal-info`,
     jobInfo: (employeeId: string) =>
       SERVICE_BASE_URL + `/employees/${employeeId}/job-info`,
+    employeeHistory: (employeeId: string) =>
+      SERVICE_BASE_URL + `/employees/${employeeId}/history`,
     employeeQrCode: (employeeId: string) => `${SERVICE_BASE_URL}/employees/${employeeId}/qr-code`,
     qrCodesSearch: SERVICE_BASE_URL + "/reports/qr-codes/search",
 

--- a/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
@@ -37,7 +37,9 @@ export interface HistoryEvent {
 }
 
 export interface PromotionRecord {
-  promotedDate: string;
+  // Nullable: HRIS holds APPROVED promotions in ended cycles whose promoted
+  // date was never populated. The timeline renders these with a "-" date.
+  promotedDate: string | null;
   currentJobBand: string;
   nextJobBand: string;
   jobRole: string;

--- a/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { State } from "@/types/types";
+import { AppConfig } from "@config/config";
+import { HttpStatusCode, isCancel } from "axios";
+import { APIService } from "@utils/apiService";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { enqueueSnackbarMessage } from "@slices/commonSlice/common";
+
+// One field-level change as returned to the client.
+//
+// `actionBy` is optional (not `T | null`) because the reduced projection strips it
+// server-side for non-privileged callers: the field is omitted from the payload
+// entirely rather than sent as null.
+export interface HistoryEvent {
+  employeePkId: number;
+  field: string;
+  previousValue: string | null;
+  currentValue: string | null;
+  occurredOn: string;
+  actionBy?: string;
+  isSystem: boolean;
+}
+
+export interface PromotionRecord {
+  promotedDate: string;
+  currentJobBand: string;
+  nextJobBand: string;
+  jobRole: string;
+  promotionType: string;
+  cycleName: string;
+  businessUnit: string;
+  department: string;
+  team: string;
+  subTeam: string;
+}
+
+export interface EmploymentPeriod {
+  id: number;
+  employeeId: string | null;
+  employmentType: string;
+  startDate: string;
+  endDate: string | null;
+  workEmail: string;
+  continuousServiceRecord: string | null;
+  promotions: PromotionRecord[];
+}
+
+export interface EmployeeHistoryResponse {
+  periods: EmploymentPeriod[];
+  events: HistoryEvent[];
+  promotionsUnavailable: boolean;
+}
+
+interface EmployeeHistoryState {
+  state: State;
+  stateMessage: string | null;
+  errorMessage: string | null;
+  history: EmployeeHistoryResponse | null;
+}
+
+const employeeHistoryInitialState: EmployeeHistoryState = {
+  state: State.idle,
+  stateMessage: null,
+  errorMessage: null,
+  history: null,
+};
+
+export const fetchEmployeeHistory = createAsyncThunk(
+  "employees/fetchEmployeeHistory",
+  async (employeeId: string, { dispatch, rejectWithValue }) => {
+    try {
+      const response = await APIService.getInstance().get(
+        AppConfig.serviceUrls.employeeHistory(employeeId),
+      );
+      return response.data as EmployeeHistoryResponse;
+    } catch (error: any) {
+      if (isCancel(error)) return rejectWithValue("cancelled");
+      const errorMessage =
+        error.response?.status === HttpStatusCode.InternalServerError
+          ? "Error while fetching employee history"
+          : error.response?.data?.message ||
+            "An unknown error occurred while fetching employee history.";
+
+      dispatch(
+        enqueueSnackbarMessage({
+          message: errorMessage,
+          type: "error",
+        }),
+      );
+
+      return rejectWithValue(errorMessage);
+    }
+  },
+);
+
+const EmployeeHistorySlice = createSlice({
+  name: "employeeHistory",
+  initialState: employeeHistoryInitialState,
+  reducers: {
+    resetEmployeeHistory(state) {
+      state.state = State.idle;
+      state.stateMessage = null;
+      state.errorMessage = null;
+      state.history = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchEmployeeHistory.pending, (state) => {
+        state.state = State.loading;
+        state.stateMessage = "Fetching employee history...";
+      })
+      .addCase(fetchEmployeeHistory.fulfilled, (state, action) => {
+        state.state = State.success;
+        state.stateMessage = "Successfully fetched employee history!";
+        state.history = action.payload;
+        state.errorMessage = null;
+      })
+      .addCase(fetchEmployeeHistory.rejected, (state, action) => {
+        state.state = State.failed;
+        state.stateMessage = "Failed to fetch employee history!";
+        state.errorMessage = action.payload as string;
+        state.history = null;
+      });
+  },
+});
+
+export const { resetEmployeeHistory } = EmployeeHistorySlice.actions;
+export default EmployeeHistorySlice.reducer;

--- a/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
@@ -29,6 +29,9 @@ import { enqueueSnackbarMessage } from "@slices/commonSlice/common";
 export interface HistoryEvent {
   employeePkId: number;
   field: string;
+  // Which audit table the change came from, used to group events into filter
+  // categories without inferring the category from the field name.
+  sourceTable: string;
   previousValue: string | null;
   currentValue: string | null;
   occurredOn: string;

--- a/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
@@ -38,8 +38,12 @@ export interface HistoryEvent {
 
 export interface PromotionRecord {
   // Nullable: HRIS holds APPROVED promotions in ended cycles whose promoted
-  // date was never populated. The timeline renders these with a "-" date.
+  // date was never populated, so this cannot be relied on for ordering.
   promotedDate: string | null;
+  // Date the request was raised. Always present, and always inside the
+  // employment period it belongs to — this is what orders promotions on the
+  // timeline and attributes them to an employment.
+  createdOn: string;
   currentJobBand: string;
   nextJobBand: string;
   jobRole: string;

--- a/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
+++ b/apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
@@ -133,6 +133,12 @@ const EmployeeHistorySlice = createSlice({
       .addCase(fetchEmployeeHistory.pending, (state) => {
         state.state = State.loading;
         state.stateMessage = "Fetching employee history...";
+        // Cleared here rather than on unmount: the slice is global, so without
+        // this a fetch for a second employee renders the first one's timeline
+        // until it resolves — stale data presented as current. Clearing in
+        // `pending` covers every entry point, not just the component's cleanup.
+        state.history = null;
+        state.errorMessage = null;
       })
       .addCase(fetchEmployeeHistory.fulfilled, (state, action) => {
         state.state = State.success;

--- a/apps/people-app/webapp/src/slices/store.ts
+++ b/apps/people-app/webapp/src/slices/store.ts
@@ -22,6 +22,7 @@ import authReducer from "@slices/authSlice/auth";
 import commonReducer from "@slices/commonSlice/common";
 import appConfigReducer from "@slices/configSlice/config";
 import employeeReducer from "@slices/employeeSlice/employee";
+import employeeHistoryReducer from "@slices/employeeSlice/employeeHistory";
 import employeePersonalInfoReducer from "@slices/employeeSlice/employeePersonalInfo";
 import userReducer from "@slices/userSlice/user";
 import organizationReducer from "@slices/organizationSlice/organization";
@@ -36,6 +37,7 @@ export const store = configureStore({
     user: userReducer,
     common: commonReducer,
     employee: employeeReducer,
+    employeeHistory: employeeHistoryReducer,
     employeePersonalInfo: employeePersonalInfoReducer,
     appConfig: appConfigReducer,
     organization: organizationReducer,

--- a/apps/people-app/webapp/src/view/me/index.tsx
+++ b/apps/people-app/webapp/src/view/me/index.tsx
@@ -87,6 +87,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { array, object, string } from "yup";
 import { Role, selectRoles } from "@slices/authSlice/auth";
 import { useAppDispatch, useAppSelector } from "@slices/store";
+import EmployeeHistory from "@component/employeeHistory/EmployeeHistory";
 
 const ReadOnly = ({
   label,
@@ -232,6 +233,7 @@ export default function Me({
     (state) => state.employeePersonalInfo,
   );
   const [isSavingChanges, setSavingChanges] = useState(false);
+  const [hasExpandedHistory, setHasExpandedHistory] = useState(false);
   const [qrDialogOpen, setQrDialogOpen] = useState(false);
   const [qrImageNaturalSize, setQrImageNaturalSize] = useState<number | null>(
     null,
@@ -1633,6 +1635,34 @@ export default function Me({
             <Typography color="text.secondary">
               Personal Information not found.
             </Typography>
+          )}
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion
+        expanded={hasExpandedHistory}
+        onChange={(_, expanded) => {
+          if (expanded) setHasExpandedHistory(true);
+        }}
+        sx={{
+          borderRadius: 2,
+          mt: 2,
+          boxShadow: 0,
+          border: 1,
+          borderColor: "divider",
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          sx={{ borderRadius: 2, backgroundColor: "background.paper" }}
+        >
+          <Typography variant="h5" sx={{ fontWeight: 600 }}>
+            History
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          {hasExpandedHistory && targetEmployeeId && (
+            <EmployeeHistory employeeId={targetEmployeeId} />
           )}
         </AccordionDetails>
       </Accordion>

--- a/apps/people-app/webapp/src/view/me/index.tsx
+++ b/apps/people-app/webapp/src/view/me/index.tsx
@@ -1092,7 +1092,6 @@ export default function Me({
         </AccordionDetails>
       </Accordion>
       <Accordion
-        defaultExpanded
         sx={{
           borderRadius: 2,
           boxShadow: 0,

--- a/apps/people-app/webapp/src/view/me/index.tsx
+++ b/apps/people-app/webapp/src/view/me/index.tsx
@@ -233,6 +233,10 @@ export default function Me({
     (state) => state.employeePersonalInfo,
   );
   const [isSavingChanges, setSavingChanges] = useState(false);
+  // Two pieces of state, deliberately: `historyExpanded` toggles with the
+  // accordion, while `hasExpandedHistory` latches on first open so the
+  // timeline stays mounted (and is not re-fetched) across collapse/expand.
+  const [historyExpanded, setHistoryExpanded] = useState(false);
   const [hasExpandedHistory, setHasExpandedHistory] = useState(false);
   const [qrDialogOpen, setQrDialogOpen] = useState(false);
   const [qrImageNaturalSize, setQrImageNaturalSize] = useState<number | null>(
@@ -1640,8 +1644,9 @@ export default function Me({
       </Accordion>
 
       <Accordion
-        expanded={hasExpandedHistory}
+        expanded={historyExpanded}
         onChange={(_, expanded) => {
+          setHistoryExpanded(expanded);
           if (expanded) setHasExpandedHistory(true);
         }}
         sx={{

--- a/docs/specs/2026-08-11-employee-history-design.md
+++ b/docs/specs/2026-08-11-employee-history-design.md
@@ -1,0 +1,254 @@
+# Employee history
+
+**Date:** 2026-08-11
+**App:** people-app (backend + webapp)
+**Status:** Approved
+
+## Problem
+
+There is no way to see how an employee's record has changed over time. The data exists —
+four audit tables capture every insert and update as a full JSON snapshot — but nothing reads it.
+Answering "when did this person move to Digital?" or "when were they last promoted?" means
+querying the audit table by hand, which is how the `unit_id` investigation was done.
+
+Two audiences need this: **People Ops**, reviewing an employee's record, and the **employee
+themselves**, on their own profile page.
+
+## Design decisions
+
+Settled explicitly; everything below follows from these.
+
+1. **Identity is the person, not the employee row.** Resolve to `personal_info_id` and gather all
+   `employee` rows for that person.
+2. **Diff at read time in Ballerina.** No new tables, no migration, works retroactively on all
+   existing audit data.
+3. **Two projections, one engine.** Employees see their own history; HR sees anyone's, with
+   attribution.
+4. **Attribution is hidden from employees.** `action_by` is HR-only.
+5. **Leaver events are shown to employees.** Including status transitions and resignation reason.
+6. **Promotions come from the HRIS database**, filtered to approved requests in ended cycles.
+
+## Why identity cannot be work email
+
+`work_email` is `NOT NULL` but **not unique** (`people_app_creation.sql:312`). Only
+`personal_info.nic_or_passport` is unique (`:215`). A rehired employee gets a *new* `employee` row,
+and the rehire flow requires the submitted work email to *match* the prior record — so one person
+legitimately owns several rows sharing one email.
+
+The reliable spine is therefore `personal_info_id`. Given an employee ID:
+
+1. `employee.employee_id` → that row's `personal_info_id`
+2. `personal_info_id` → every `employee` row for the person
+3. `continuous_service_record` (FK to `employee.id`) links successive employments explicitly
+
+Building on work email would silently merge or split people.
+
+## Design
+
+### 1. Endpoint
+
+`GET /employees/{employeeId}/history`, following the existing `employees/[employeeId]/personal-info`
+shape in `service.bal`.
+
+Authorization mirrors the established pattern — extract `userInfo` from `ctx`, check privileges:
+
+- **ADMIN** — any employee's history, full projection.
+- **EMPLOYEE** — own history only, filtered projection. The caller's email must resolve to the same
+  `personal_info_id` as the requested employee ID; otherwise `403`.
+
+### 2. Deriving change events
+
+The audit tables store whole snapshots, not deltas, so the diff happens at read time:
+
+1. Collect every `employee_pk_id` belonging to the person.
+2. Fetch matching rows from `employee_audit`, `personal_info_audit`, and
+   `employee_additional_managers_audit`, ordered by `action_on`.
+3. For each consecutive pair, compare the JSON field by field.
+4. Emit one event per changed field: field name, old value, new value, timestamp, and `action_by`.
+
+**Fields tracked** (from `employee_audit`): `business_unit_id`, `team_id`, `sub_team_id`, `unit_id`,
+`designation_id`, `employment_type_id`, `company_id`, `office_id`, `manager_email`,
+`employee_status`, `work_location`, `job_role`, `secondary_job_title`, `external_designation`,
+`house_id`, `epf`, `probation_end_date`, `agreement_end_date`, `start_date`.
+
+**Fields ignored** as noise: `updated_on`, `updated_by`, `employee_thumbnail`, `created_on`,
+`created_by`, and `id`. An audit row whose only differences are ignored fields produces no event.
+
+This matters more than it sounds. The `unit_id` investigation found 5000 audit rows containing
+roughly 150 real field changes — the rest were migration re-writes touching only `updated_on` and
+`employee_thumbnail`. Without filtering, the timeline is unreadable.
+
+Events where `action_by = 'MIGRATION'` are labelled as system activity rather than shown as a
+person editing a record.
+
+### 3. Resolving IDs to names
+
+Audit JSON stores foreign keys (`business_unit_id`, `designation_id`, …). Resolving them means
+joining to the current lookup tables, which yields *today's* name. If a team was renamed, an old
+event displays the new name.
+
+This is accepted rather than solved: master data is not versioned, and versioning it is a far
+larger change than this feature. Documented here so it is a known limitation, not a surprise.
+
+### 4. Employment periods
+
+Each `employee` row is one employment period, with its own employee ID and employment type. The
+history groups events under the period they belong to, ordered most recent first, with
+`continuous_service_record` shown as an explicit link between successive periods.
+
+```
+━━ Permanent · EP1234 · Jan 2024 – present
+   12 Jun 2026  Team          Platform → Digital
+   03 Mar 2026  Designation   SSE → SSE II        [promotion]
+   01 Jan 2024  Joined
+━━ Internship · IN0456 · Jun 2023 – Dec 2023   (continuous service)
+   01 Dec 2023  Status        Active → Left
+```
+
+### 5. Promotion history (HRIS database)
+
+Promotions come from a **second, separate MySQL database** (`hris`) that the People App backend
+does not currently connect to. This adds a `promotionDbConfig` configurable and a second SQL client.
+
+> **Credential note:** the HRIS credentials must go in `Config.toml` (gitignored) with empty
+> placeholders added to `Config.toml.local` (checked in), per the project's config convention.
+> Never commit the real password.
+
+**The query** — an approved request whose cycle has formally ended:
+
+```sql
+SELECT pr.promotion_request_promoted_date,
+       pr.promotion_request_current_job_band,
+       pr.promotion_request_requested_job_band,
+       pr.promotion_request_current_job_role,
+       pr.promotion_request_type,
+       pr.promotion_request_business_unit,
+       pr.promotion_request_department,
+       pr.promotion_request_team,
+       pr.promotion_request_sub_team,
+       pc.promotion_cycle_name
+FROM hris.hris_promotion_request pr
+JOIN hris.hris_promotion_cycle pc ON pc.promotion_cycle_id = pr.promotion_cycle_id
+WHERE pr.promotion_request_employee_email = ${workEmail}
+  AND pr.promotion_request_status = 'APPROVED'
+  AND pc.promotion_cycle_status = 'END'
+  AND pr.promotion_request_promoted_date IS NOT NULL
+ORDER BY pr.promotion_request_promoted_date DESC
+```
+
+**Both conditions are load-bearing:**
+
+- `promotion_request_status` has **ten** values (`DRAFT, SUBMITTED, WITHDRAW, REMOVED, EXPIRED,
+  REJECTED, APPROVED, FL_REJECTED, FL_APPROVED, PROCESSING`). Only `APPROVED` is a completed
+  promotion — note `FL_APPROVED` is *functional-lead* approved, an intermediate state, and must not
+  be treated as a promotion. Surfacing `REJECTED` or `FL_REJECTED` to an employee would disclose
+  that a promotion was proposed and declined.
+- `promotion_cycle_status` has **three** values (`OPEN, CLOSED, END`). `END` is terminal: HR Admin
+  ends a cycle via `/promotion/cycles/{id}/end`, which also expires all pending requests
+  (`service.bal:579-610`). A merely `CLOSED` cycle may still have decisions in flight, so only
+  `END` counts.
+
+**Date normalisation.** Promoted dates are inconsistently stored, some with slashes. The promotion
+app normalises with `regex:replaceAll(re '/', date, "-")` (`functions.bal:132`). Copy this, or dates
+render wrong.
+
+**Do not use `employee.last_promoted_date`.** The promotion app deliberately overrides the
+People-side value, with the comment *"TODO: Remove this after the fix for the incorrect last
+promotion date in people hr sync db"* (`functions.bal:100`). The synced value is known to be wrong;
+the HRIS database is the source of truth.
+
+**Attribution to an employment period.** Promotions key on work email only, so for a rehired person
+every promotion across all periods returns together. Each is assigned to the period whose date
+range contains its `promotion_request_promoted_date`.
+
+**Failure handling.** If the HRIS database is unreachable, the endpoint still returns the People App
+history, with a flag indicating promotion history is unavailable. A second database outage must not
+break the Me page. The error is logged.
+
+### 6. The two projections
+
+| | Employee (own record) | HR / Admin |
+|---|---|---|
+| Field change events | ✅ | ✅ |
+| Employment periods and rehires | ✅ | ✅ |
+| Promotions (APPROVED + cycle END) | ✅ | ✅ |
+| Leaver events, resignation reason | ✅ | ✅ |
+| `action_by` attribution | ❌ | ✅ |
+| Migration/system events | filtered out | included, labelled |
+
+### 7. Frontend
+
+- **Me page** (`view/me/index.tsx`) — a history section showing the employee's own timeline.
+- **Employee detail** — the same component with the HR projection, for ADMIN.
+
+Both render from one endpoint; the component takes the event list and groups by employment period.
+The projection is decided server-side by privilege, not by a prop — the client never receives
+attribution it is not permitted to show.
+
+#### Approved layout
+
+A reviewed mockup exists and was approved. Build to it:
+`docs/specs/assets/2026-08-11-employee-history-mockup.html`
+
+Structure, outermost to innermost:
+
+- **Employment periods** as sections, most recent first. Each header carries employment type,
+  employee ID, and the date span. A rehired period shows an explicit "Continuous service — linked
+  to …" line beneath its header, derived from `continuous_service_record`.
+- **A vertical spine** within each period, with one dated event per row hanging off it.
+- **Each event row** is a three-column grid: marker, date, content. Content is a small uppercase
+  field label above the change itself.
+- **Changes render as `old → new`**, with the old value struck through and the new value in medium
+  weight. Scanning the right-hand column gives the current state; the struck values give the path.
+- **Single-value events** (Joined, Promotion) render one value rather than a transition.
+
+Visual language:
+
+- **Palette is the app's own** (`webapp/src/theme.ts`) — neutral slate, no invented brand hue.
+- **The accent (`#f14e23`, WSO2 orange) marks promotions only.** It is not decoration; it is the
+  one thing on the timeline sourced from a different system.
+- **Semantic colours are separate from the accent** and carry status meaning only: green for an
+  active/normal state, amber for *Marked leaver*, red for *Left*.
+- **Dates use tabular numerals** so the date column aligns down the page.
+- Both light and dark themes are defined at token level.
+
+Two details settled during review:
+
+- **Same-day changes stay as separate rows.** An org move that touches team and sub-team on one
+  date reads as two rows sharing a date. Grouping was considered and rejected: the fields change
+  independently in the data, and collapsing them would imply an atomicity the audit trail does not
+  record.
+- **System/migration events are collapsed and counted**, not listed individually — "5 runs
+  collapsed" on one row in the HR view, absent entirely in the employee view.
+
+## Accepted trade-offs
+
+- **Leaver events are visible to employees before they may have been told.** HR sets *Marked
+  leaver* with a future final day — the scheduler depends on this — so a record can carry that
+  status for weeks before the conversation. An employee opening their history in that window sees
+  it, including HR's resignation-reason categorisation. This was raised and confirmed as intended.
+- **Renamed master data displays under its current name** in historical events (see §3).
+- **A promotion approved in a `CLOSED` but not yet `END`ed cycle is hidden** until an admin formally
+  ends the cycle, which may lag.
+
+## Out of scope
+
+- No new tables, no migration, no backfill.
+- No versioning of master-data names.
+- No eligibility logic — job-band thresholds and service-year calculations belong to the promotion
+  app.
+- No microapp change.
+- No write path: history is read-only.
+
+## Files affected
+
+| File | Change |
+|---|---|
+| `backend/Config.toml.local` | *(modify)* Empty `[people.promotion_db]` placeholder block |
+| `backend/modules/database/*` | *(modify)* Audit queries, person resolution, diff engine |
+| `backend/modules/promotion/` | *(create)* Second SQL client and the promotion query |
+| `backend/types.bal` | *(modify)* History event and response types |
+| `backend/service.bal` | *(modify)* `GET /employees/{employeeId}/history` with privilege filtering |
+| `webapp/src/slices/employeeSlice/*` | *(modify)* History fetch thunk and state |
+| `webapp/src/view/me/index.tsx` | *(modify)* History section |
+| `webapp/src/view/employees/...` | *(modify)* History view for ADMIN |

--- a/docs/specs/2026-08-11-employee-history-plan.md
+++ b/docs/specs/2026-08-11-employee-history-plan.md
@@ -1,0 +1,599 @@
+# Employee History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give People Ops and employees a timeline of how an employee's record has changed, assembled by diffing the existing audit tables at read time and merged with promotion history from the HRIS database.
+
+**Architecture:** A new `GET /employees/{employeeId}/history` endpoint. Identity resolves through `personal_info_id` so a rehired person yields one history across several employment rows. Audit snapshots are diffed in Ballerina — no new tables, no migration. Promotions come from a second MySQL client in a dedicated `promotion` module. The response is filtered by privilege server-side: employees get their own history without attribution, ADMIN gets anyone's with it.
+
+**Tech Stack:** Ballerina 2201.12.7, MySQL, React 18 (CRA + react-app-rewired), TypeScript, MUI v5, Redux Toolkit.
+
+**Spec:** `docs/specs/2026-08-11-employee-history-design.md`
+**Approved mockup:** `docs/specs/assets/2026-08-11-employee-history-mockup.html`
+
+## Global Constraints
+
+- **Identity is `personal_info_id`, never `work_email`.** `work_email` is `NOT NULL` but not unique (`people_app_creation.sql:312`); only `personal_info.nic_or_passport` is unique (`:215`). A rehired employee owns several `employee` rows sharing one email. Building on email silently merges or splits people.
+- **Read-only feature.** No new tables, no migration, no backfill, no writes to any audit table.
+- **Promotion filter is two conditions, both required:** `promotion_request_status = 'APPROVED'` AND `promotion_cycle_status = 'END'`. `FL_APPROVED` is functional-lead approved — an intermediate state, not a promotion. A `CLOSED` cycle may still have decisions in flight.
+- **Never surface `REJECTED`, `FL_REJECTED`, `WITHDRAW`, or `EXPIRED` promotion requests** in either projection.
+- **Never write the HRIS password into the repo.** `Config.toml.local` is checked in and gets empty placeholders only. Real values go in `Config.toml`, which is gitignored.
+- **Do not read `employee.last_promoted_date`.** The promotion app overrides it because the synced value is known wrong (`promotion-app functions.bal:100`). HRIS is the source of truth.
+- Backend: keep resource functions in `service.bal`, business logic in modules. Every new `configurable` gets a placeholder in `Config.toml.local` in the same commit.
+- Webapp: path aliases (`@slices/`, `@view/`, `@component/`), never relative `../../`. MUI `sx` + `useTheme()`. Nullable as `field: T | null`.
+- Staging: the tree has unrelated modified files. Stage only what each task names, path-scoped. Never `git add -A` / `git add .` / `git commit -am`.
+- `bal build` must succeed and `./node_modules/.bin/tsc --noEmit` must stay at zero errors. Use the local tsc binary, not `npx tsc` (npx masks the exit code here).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/modules/promotion/client.bal` | *(create)* HRIS MySQL client + `promotionDbConfig` |
+| `backend/modules/promotion/types.bal` | *(create)* `PromotionRecord`, config type |
+| `backend/modules/promotion/queries.bal` | *(create)* The APPROVED + END query |
+| `backend/modules/promotion/functions.bal` | *(create)* Fetch + date normalisation |
+| `backend/Config.toml.local` | *(modify)* Empty `[people.promotion.promotionDbConfig]` block |
+| `backend/modules/database/db_queries.bal` | *(modify)* Person resolution + audit-fetch queries |
+| `backend/modules/database/db_functions.bal` | *(modify)* Audit fetch, employment periods |
+| `backend/modules/database/history.bal` | *(create)* The diff engine — snapshot pairs → events |
+| `backend/modules/database/types.bal` | *(modify)* History event and period types |
+| `backend/service.bal` | *(modify)* `GET /employees/[employeeId]/history` + privilege filter |
+| `webapp/src/config/config.ts` | *(modify)* Endpoint URL |
+| `webapp/src/slices/employeeSlice/employeeHistory.ts` | *(create)* Slice + fetch thunk |
+| `webapp/src/component/employeeHistory/EmployeeHistory.tsx` | *(create)* Timeline component |
+| `webapp/src/view/me/index.tsx` | *(modify)* Collapsed history section — the only view to change; `EmployeeDetail` already renders this component |
+
+Tasks are ordered so each is independently reviewable and nothing renders before its data exists.
+
+---
+
+### Task 1: HRIS promotion module
+
+**Files:**
+- Create: `backend/modules/promotion/client.bal`, `types.bal`, `queries.bal`, `functions.bal`
+- Modify: `backend/Config.toml.local`
+
+**Interfaces:**
+- Consumes: nothing in this repo.
+- Produces: `promotion:getApprovedPromotions(string workEmail) returns PromotionRecord[]|error`, where `PromotionRecord` carries `promotedDate`, `currentJobBand`, `nextJobBand`, `jobRole`, `promotionType`, `cycleName`, `businessUnit`, `department`, `team`, `subTeam`.
+
+- [ ] **Step 1: Create the config type and client**
+
+`types.bal` — mirror the shape of `database:DatabaseConfig`:
+
+```ballerina
+# HRIS promotion database configuration.
+public type PromotionDatabaseConfig record {|
+    # Database user
+    string user;
+    # Database password
+    string password;
+    # Database name
+    string database;
+    # Database host
+    string host;
+    # Connection pool configuration
+    sql:ConnectionPool connectionPool?;
+|};
+```
+
+`client.bal` — follow `modules/database/client.bal` exactly:
+
+```ballerina
+import ballerinax/mysql;
+import ballerinax/mysql.driver as _;
+
+# HRIS promotion database client configuration.
+configurable PromotionDatabaseConfig promotionDbConfig = ?;
+
+function initPromotionDbClient() returns mysql:Client|error => new (...promotionDbConfig);
+
+# HRIS promotion database client.
+final mysql:Client promotionDbClient = check initPromotionDbClient();
+```
+
+- [ ] **Step 2: Add the config placeholder**
+
+In `Config.toml.local`, after the `[people.database.dbConfig]` block, add **empty placeholders only**:
+
+```toml
+[people.promotion.promotionDbConfig]
+    host = ""
+    user = ""
+    password = ""
+    database = ""
+    [people.promotion.promotionDbConfig.connectionPool]
+    maxOpenConnections =
+    maxConnectionLifeTime =
+    minIdleConnections =
+```
+
+**Do not put real credentials here.** This file is checked in.
+
+- [ ] **Step 3: Write the query**
+
+`queries.bal`:
+
+```ballerina
+# Approved promotions for an employee, from cycles that have formally ended.
+#
+# + workEmail - Work email of the employee
+# + return - Parameterized query returning approved promotions, newest first
+isolated function getApprovedPromotionsQuery(string workEmail) returns sql:ParameterizedQuery =>
+    `SELECT
+        pr.promotion_request_promoted_date AS promotedDate,
+        pr.promotion_request_current_job_band AS currentJobBand,
+        pr.promotion_request_requested_job_band AS nextJobBand,
+        pr.promotion_request_current_job_role AS jobRole,
+        pr.promotion_request_type AS promotionType,
+        pr.promotion_request_business_unit AS businessUnit,
+        pr.promotion_request_department AS department,
+        pr.promotion_request_team AS team,
+        pr.promotion_request_sub_team AS subTeam,
+        pc.promotion_cycle_name AS cycleName
+    FROM hris_promotion_request pr
+        JOIN hris_promotion_cycle pc ON pc.promotion_cycle_id = pr.promotion_cycle_id
+    WHERE pr.promotion_request_employee_email = ${workEmail}
+        AND pr.promotion_request_status = 'APPROVED'
+        AND pc.promotion_cycle_status = 'END'
+        AND pr.promotion_request_promoted_date IS NOT NULL
+    ORDER BY pr.promotion_request_promoted_date DESC`;
+```
+
+Both status conditions are load-bearing — see Global Constraints.
+
+- [ ] **Step 4: Fetch with date normalisation**
+
+`functions.bal`:
+
+```ballerina
+# Fetch approved promotions for an employee from the HRIS database.
+#
+# + workEmail - Work email of the employee
+# + return - Approved promotions newest first, or an error
+public isolated function getApprovedPromotions(string workEmail) returns PromotionRecord[]|error {
+    stream<PromotionRecord, error?> resultStream =
+        promotionDbClient->query(getApprovedPromotionsQuery(workEmail));
+
+    PromotionRecord[] promotions = check from PromotionRecord promotion in resultStream
+        select promotion;
+
+    // Promoted dates are inconsistently stored; some use slashes. The promotion app
+    // normalises the same way (promotion-app functions.bal:132).
+    return from PromotionRecord promotion in promotions
+        select {
+            ...promotion,
+            promotedDate: re `/`.replaceAll(promotion.promotedDate, "-")
+        };
+}
+```
+
+- [ ] **Step 5: Build**
+
+Run: `cd apps/people-app/backend && bal build`
+Expected: BUILD SUCCESSFUL. The pre-existing `debezium` jar-conflict warning is unrelated and expected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/people-app/backend/modules/promotion apps/people-app/backend/Config.toml.local
+git commit -m "feat(people-app): add HRIS promotion database module"
+```
+
+---
+
+### Task 2: Person resolution and audit fetch
+
+**Files:**
+- Modify: `backend/modules/database/db_queries.bal`, `db_functions.bal`, `types.bal`
+
+**Interfaces:**
+- Consumes: existing `employee`, `personal_info`, `employee_audit`, `personal_info_audit`, `employee_additional_managers_audit` tables.
+- Produces:
+  - `getEmploymentPeriods(string employeeId) returns EmploymentPeriod[]|error` — every employment row for the person behind that employee ID, newest first.
+  - `getAuditSnapshots(int[] employeePkIds) returns AuditSnapshot[]|error` — raw audit rows ordered by `action_on` ascending.
+
+- [ ] **Step 1: Add the types**
+
+In `types.bal`:
+
+```ballerina
+# One employment period for a person.
+public type EmploymentPeriod record {|
+    # Employee table primary key
+    int id;
+    # Employee ID (e.g. "EP 10006")
+    string? employeeId;
+    # Employment type name
+    string employmentType;
+    # Start date
+    string startDate;
+    # Final day of employment, if the period has ended
+    string? endDate;
+    # Work email
+    string workEmail;
+    # Employee ID of the prior linked employment, if any
+    string? continuousServiceRecord;
+|};
+
+# A raw audit row awaiting diffing.
+public type AuditSnapshot record {|
+    # Employee table primary key this snapshot belongs to
+    int employeePkId;
+    # Source table this snapshot came from
+    string sourceTable;
+    # INSERT or UPDATE
+    string actionType;
+    # Who performed the action
+    string actionBy;
+    # When the action occurred
+    string actionOn;
+    # The full row snapshot as JSON
+    json data;
+|};
+```
+
+- [ ] **Step 2: Resolve the person and their employment periods**
+
+The query resolves employee ID → `personal_info_id` → every employment row for that person:
+
+```ballerina
+# All employment periods for the person behind an employee ID.
+#
+# + employeeId - Employee ID of any one of the person's employment records
+# + return - Parameterized query returning every employment period, newest first
+isolated function getEmploymentPeriodsQuery(string employeeId) returns sql:ParameterizedQuery =>
+    `SELECT
+        e.id AS id,
+        e.employee_id AS employeeId,
+        et.name AS employmentType,
+        e.start_date AS startDate,
+        r.final_day_of_employment AS endDate,
+        e.work_email AS workEmail,
+        csr.employee_id AS continuousServiceRecord
+    FROM employee e
+        JOIN employment_type et ON et.id = e.employment_type_id
+        LEFT JOIN resignation r ON r.employee_id = e.id
+        LEFT JOIN employee csr ON csr.id = e.continuous_service_record
+    WHERE e.personal_info_id = (
+        SELECT personal_info_id FROM employee WHERE employee_id = ${employeeId}
+    )
+    ORDER BY e.start_date DESC`;
+```
+
+The subquery is what makes a rehire one history. Do **not** rewrite this to match on `work_email`.
+
+- [ ] **Step 3: Fetch audit snapshots**
+
+One query per audit table, each filtered by the person's `employee_pk_id` set and ordered by `action_on` ascending, so consecutive rows can be diffed. Use `sql:queryConcat` with an IN clause built from the ID array, following the existing `buildInClause` pattern (`people-scheduler/modules/database/queries.bal:39`).
+
+Note that helper takes `string[]`, while these IDs are `int[]` — either convert with `.toString()` or write an int variant in the `database` module. Do not interpolate the array directly into the query.
+
+Tables to read: `employee_audit`, `personal_info_audit`, `employee_additional_managers_audit`. Tag each row with its `sourceTable` so the diff engine knows which field map to use.
+
+- [ ] **Step 4: Add the DB functions**
+
+In `db_functions.bal`, add `getEmploymentPeriods` and `getAuditSnapshots` following the existing function style — `databaseClient->query(...)`, collect the stream, `check` on error.
+
+- [ ] **Step 5: Build**
+
+Run: `cd apps/people-app/backend && bal build`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/people-app/backend/modules/database/db_queries.bal apps/people-app/backend/modules/database/db_functions.bal apps/people-app/backend/modules/database/types.bal
+git commit -m "feat(people-app): resolve employment periods and fetch audit snapshots"
+```
+
+---
+
+### Task 3: The diff engine
+
+**Files:**
+- Create: `backend/modules/database/history.bal`
+- Modify: `backend/modules/database/types.bal`
+
+**Interfaces:**
+- Consumes: `AuditSnapshot[]` (Task 2).
+- Produces: `buildHistoryEvents(AuditSnapshot[] snapshots) returns HistoryEvent[]` — one event per changed field, newest first.
+
+This is the heart of the feature. The audit tables store whole snapshots, not deltas, so events are derived by comparing consecutive snapshots for the same `employee_pk_id`.
+
+- [ ] **Step 1: Add the event type**
+
+```ballerina
+# One field-level change derived from consecutive audit snapshots.
+public type HistoryEvent record {|
+    # Employee table primary key this event belongs to
+    int employeePkId;
+    # Canonical field key (e.g. "team_id")
+    string 'field;
+    # Value before the change, if any
+    string? previousValue;
+    # Value after the change
+    string? currentValue;
+    # When the change occurred
+    string occurredOn;
+    # Who made the change
+    string actionBy;
+    # True when actionBy is a system actor rather than a person
+    boolean isSystem;
+|};
+```
+
+- [ ] **Step 2: Define which fields are tracked**
+
+```ballerina
+# Employee fields surfaced in the history. Everything else in the audit
+# snapshot is either noise or not meaningful to a reader.
+final readonly & string[] TRACKED_EMPLOYEE_FIELDS = [
+    "business_unit_id", "team_id", "sub_team_id", "unit_id",
+    "designation_id", "employment_type_id", "company_id", "office_id",
+    "manager_email", "employee_status", "work_location",
+    "job_role", "secondary_job_title", "external_designation",
+    "house_id", "epf", "probation_end_date", "agreement_end_date", "start_date"
+];
+```
+
+Deliberately excluded as noise: `updated_on`, `updated_by`, `created_on`, `created_by`, `employee_thumbnail`, `id`.
+
+This exclusion is not cosmetic. The `unit_id` investigation found 5000 audit rows containing roughly 150 real field changes — the remainder were migration re-writes touching only `updated_on` and `employee_thumbnail`. Without filtering, the timeline is unusable.
+
+- [ ] **Step 3: Implement the diff**
+
+```ballerina
+# Derive field-level change events by comparing consecutive audit snapshots.
+#
+# Snapshots must arrive ordered by action_on ascending, grouped per employee_pk_id.
+# An INSERT yields no change events — it is the baseline the first UPDATE is compared against.
+#
+# + snapshots - Audit snapshots ordered oldest first
+# + return - One event per changed tracked field, newest first
+public isolated function buildHistoryEvents(AuditSnapshot[] snapshots) returns HistoryEvent[] {
+    HistoryEvent[] events = [];
+    map<json> previousByEmployee = {};
+
+    foreach AuditSnapshot snapshot in snapshots {
+        string key = snapshot.employeePkId.toString();
+        json? previous = previousByEmployee[key];
+
+        if previous is json {
+            foreach string 'field in TRACKED_EMPLOYEE_FIELDS {
+                json previousValue = getField(previous, 'field);
+                json currentValue = getField(snapshot.data, 'field);
+
+                if previousValue != currentValue {
+                    events.push({
+                        employeePkId: snapshot.employeePkId,
+                        'field: 'field,
+                        previousValue: toDisplayValue(previousValue),
+                        currentValue: toDisplayValue(currentValue),
+                        occurredOn: snapshot.actionOn,
+                        actionBy: snapshot.actionBy,
+                        isSystem: isSystemActor(snapshot.actionBy)
+                    });
+                }
+            }
+        }
+
+        previousByEmployee[key] = snapshot.data;
+    }
+
+    return events.reverse();
+}
+```
+
+Helpers in the same file: `getField` (safe JSON member access returning `()` when absent), `toDisplayValue` (JSON scalar → `string?`), and `isSystemActor` (true for `MIGRATION` and `system-scheduler`).
+
+- [ ] **Step 4: Build**
+
+Run: `cd apps/people-app/backend && bal build`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/people-app/backend/modules/database/history.bal apps/people-app/backend/modules/database/types.bal
+git commit -m "feat(people-app): derive history events by diffing audit snapshots"
+```
+
+---
+
+### Task 4: The endpoint
+
+**Files:**
+- Modify: `backend/service.bal`, `backend/types.bal`
+
+**Interfaces:**
+- Consumes: `getEmploymentPeriods`, `getAuditSnapshots`, `buildHistoryEvents` (Tasks 2-3); `promotion:getApprovedPromotions` (Task 1).
+- Produces: `GET /employees/{employeeId}/history` returning periods, events, promotions, and a `promotionsUnavailable` flag.
+
+- [ ] **Step 1: Add the resource function**
+
+Follow the shape of the existing `get employees/[string employeeId]` at `service.bal:182`: extract `userInfo` from `ctx`, check privileges, call the module, map errors to the standard error responses.
+
+**Authorization, and it must be exactly this:**
+
+- ADMIN → any employee's history, full projection.
+- Otherwise → the caller may only read their own. Resolve the caller's email to a `personal_info_id` and compare with the requested employee's. **Compare on `personal_info_id`, not on email or employee ID** — a rehired person has several employee IDs, and comparing IDs would wrongly deny access to their own earlier employment. Mismatch returns `403`.
+
+- [ ] **Step 2: Assemble the response**
+
+1. Resolve employment periods.
+2. Fetch audit snapshots for every `employee_pk_id` in those periods.
+3. Build history events.
+4. Fetch promotions using the work email from the periods.
+5. Assign each promotion to the period whose `startDate`–`endDate` range contains its `promotedDate`. A promotion outside every range attaches to the nearest earlier period.
+6. Apply the projection filter (Step 3).
+
+**Promotion failure must not fail the request.** Wrap the `promotion:getApprovedPromotions` call so an error logs and sets `promotionsUnavailable: true` while the rest of the response returns normally. A second-database outage must not break the Me page.
+
+- [ ] **Step 3: Apply the projection filter**
+
+Filter server-side, never client-side — the client must not receive data it is not permitted to show.
+
+For a non-ADMIN caller:
+- Strip `actionBy` from every event.
+- Drop events where `isSystem` is true.
+
+For ADMIN: return everything, with `isSystem` intact so the UI can label and collapse system rows.
+
+Leaver events (status transitions, resignation reason) are returned in **both** projections — see the spec's accepted trade-offs.
+
+- [ ] **Step 4: Build**
+
+Run: `cd apps/people-app/backend && bal build`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/people-app/backend/service.bal apps/people-app/backend/types.bal
+git commit -m "feat(people-app): add employee history endpoint"
+```
+
+---
+
+### Task 5: Webapp data layer
+
+**Files:**
+- Modify: `webapp/src/config/config.ts`
+- Create: `webapp/src/slices/employeeSlice/employeeHistory.ts`
+
+**Interfaces:**
+- Consumes: the endpoint from Task 4.
+- Produces: `fetchEmployeeHistory` thunk and `employeeHistory` slice state, consumed by Task 6.
+
+- [ ] **Step 1: Add the endpoint URL**
+
+In `config.ts`, add to `AppConfig.serviceUrls` following the existing entries. Never hard-code URLs in components or thunks.
+
+- [ ] **Step 2: Create the slice**
+
+Follow the existing slice pattern exactly — `createAsyncThunk`, the `State` enum (`idle | loading | success | failed`), `isCancel(error)` checked first, `enqueueSnackbarMessage` on error, `rejectWithValue`. Use `APIService.getInstance()`; never import raw axios.
+
+Types mirror the API response: `HistoryEvent`, `EmploymentPeriod`, `PromotionRecord`, and the wrapper carrying `promotionsUnavailable`. Nullable fields as `T | null`.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd apps/people-app/webapp && ./node_modules/.bin/tsc --noEmit -p tsconfig.json`
+Expected: exit 0, zero output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/people-app/webapp/src/config/config.ts apps/people-app/webapp/src/slices/employeeSlice/employeeHistory.ts
+git commit -m "feat(people-app): add employee history slice and endpoint config"
+```
+
+---
+
+### Task 6: The timeline component
+
+**Files:**
+- Create: `webapp/src/component/employeeHistory/EmployeeHistory.tsx`
+- Modify: `webapp/src/view/me/index.tsx`, and the employee detail view
+
+**Interfaces:**
+- Consumes: the slice from Task 5.
+- Produces: a rendered timeline on the Me page and the employee detail view.
+
+**Build to the approved mockup:** `docs/specs/assets/2026-08-11-employee-history-mockup.html`. Open it before starting — it is the reference for structure and visual language, not a suggestion.
+
+- [ ] **Step 1: Build the component**
+
+Structure, outermost to innermost:
+
+- **Employment periods** as sections, newest first. Header carries employment type, employee ID, and date span. A period with a `continuousServiceRecord` shows the "Continuous service — linked to …" line beneath its header.
+- **A vertical spine** per period, one dated event row hanging off it.
+- **Event rows** as a three-column grid: marker, date, content. Content is an uppercase field label above the change.
+- **Changes render `old → new`**, old struck through, new in medium weight. Single-value events (Joined, Promotion) render one value.
+- **Promotions** carry the accent marker and a detail strip with cycle, type, and role.
+
+Visual language, per the mockup:
+
+- Palette from `theme.ts` via `useTheme()` — no invented colours.
+- The accent marks promotions only.
+- Semantic colours carry status meaning: normal, `Marked leaver`, `Left`.
+- `fontVariantNumeric: "tabular-nums"` on dates so the column aligns.
+- System/migration rows collapsed with a count, shown only when present (ADMIN only — the API omits them otherwise).
+
+Field keys arrive as raw column names (`team_id`, `sub_team_id`). Map them to readable labels ("Team", "Sub-team") in the component.
+
+- [ ] **Step 2: Render it in one place — `view/me/index.tsx`**
+
+**There is only one page to modify.** `EmployeeDetail` (`view/employees/employeeDetail/employeeDetail.tsx`) is a 23-line wrapper that renders `<Me employeeId={...} readOnly />`. So the employee's own profile (`/`) and an admin viewing someone (`/employees/:employeeId`) are the *same* component with different props. Add the section once and it appears in both.
+
+Placement, per the approved decision: a **collapsed `Paper` section at the bottom** of the page, below the existing detail grids, following the page's existing Paper-section rhythm. Header reads "History" with an expand control; collapsed by default so the default page length is unchanged — a long-tenured employee's timeline can run to dozens of events.
+
+Fetch **lazily, on first expand**, not on mount. There is no reason to query the audit tables and a second database for a section the user has not opened.
+
+Handle all four states inside the expanded section: loading, empty (no events recorded yet), success, failed.
+
+When `promotionsUnavailable` is true, show an inline note that promotion history is temporarily unavailable — the rest of the timeline still renders.
+
+**Which projection renders is decided by the API, not the component.** The component displays whatever it receives; attribution and system rows are present for ADMIN and absent otherwise. Do not branch on `readOnly` to decide what to show — that would put an authorization decision in the client.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd apps/people-app/webapp && ./node_modules/.bin/tsc --noEmit -p tsconfig.json`
+Expected: exit 0, zero output.
+
+- [ ] **Step 4: Manual verification**
+
+Requires a running backend with HRIS connectivity. If unavailable, report that plainly — do not claim these were performed.
+
+1. The Me page shows a collapsed **History** section at the bottom; expanding it loads the timeline, and nothing is fetched before the first expand.
+2. A rehired employee shows multiple employment periods, linked by continuous service.
+3. Changes render `old → new` with readable field labels, not raw column names.
+4. Dates align in their column.
+5. An employee's own view shows **no** attribution and **no** system/migration rows.
+6. An ADMIN viewing the same employee sees attribution and collapsed system rows.
+7. A promotion renders with the accent marker, correct job bands, and cycle name.
+8. Stopping the HRIS database still renders the timeline, with the unavailable note.
+9. An employee requesting another employee's history receives 403.
+10. The same section appears on `/employees/:employeeId` for an admin, since `EmployeeDetail` renders the same component.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/people-app/webapp/src/component/employeeHistory apps/people-app/webapp/src/view/me/index.tsx
+git commit -m "feat(people-app): render employee history timeline"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Identity via `personal_info_id` | Task 2 Step 2, Task 4 Step 1 |
+| Read-time diffing, no migration | Task 3 |
+| Noise filtering (`updated_on`, thumbnails) | Task 3 Step 2 |
+| System actors labelled | Task 3 Step 3, Task 4 Step 3 |
+| Employment periods + continuous service | Task 2 Step 2, Task 6 Step 1 |
+| Promotions: APPROVED + cycle END | Task 1 Step 3 |
+| Promotion date normalisation | Task 1 Step 4 |
+| Promotions attributed to a period | Task 4 Step 2 |
+| HRIS failure degrades gracefully | Task 4 Step 2, Task 6 Step 2 |
+| Attribution hidden from employees | Task 4 Step 3 |
+| Leaver events shown to employees | Task 4 Step 3 (explicit) |
+| Approved UI built to the mockup | Task 6 |
+| Credentials never committed | Global Constraints, Task 1 Step 2 |
+| No new tables / migration / backfill | Global Constraints |
+
+**Type consistency:** `HistoryEvent`, `EmploymentPeriod`, and `PromotionRecord` are declared once in Ballerina (Tasks 1-3) and mirrored in TypeScript (Task 5). Field names match across the boundary.
+
+**Placeholder scan:** no TBDs. Task 2 Step 3 and Task 6 Step 1 describe patterns rather than quoting full code — both point at a concrete existing example to follow (`buildInClause`, the mockup file).
+
+**Known risks:**
+- **Task 3 is the correctness-critical task.** A wrong diff silently produces a plausible but false history. The INSERT-is-baseline rule matters: treating an INSERT as a change would show every field "changing" at hire.
+- **Task 4's authorization check** must compare `personal_info_id`, not employee ID. Comparing IDs would deny a rehired person access to their own earlier employment.
+- **Task 1 cannot be verified without HRIS connectivity.** `bal build` proves it compiles, nothing more.
+- No automated tests exist in this backend; every task's verification is a build plus manual checks.

--- a/docs/specs/assets/2026-08-11-employee-history-mockup.html
+++ b/docs/specs/assets/2026-08-11-employee-history-mockup.html
@@ -1,0 +1,417 @@
+<title>Employee History — People App</title>
+
+<style>
+  :root {
+    --ink:        #2f3438;
+    --ink-2:      #5a5d61;
+    --muted:      #82868a;
+    --faint:      #a8abad;
+    --rule:       #dfe1e3;
+    --rule-soft:  #ecedee;
+    --ground:     #f7f8f8;
+    --surface:    #ffffff;
+    --spine:      #d6d8da;
+    --accent:     #f14e23;
+    --accent-dim: #fbe4dc;
+    --ok:         #388e3c;
+    --warn:       #b08d3c;
+    --stop:       #d93a2b;
+    --ok-bg:      #e8f2e9;
+    --warn-bg:    #f6efdc;
+    --stop-bg:    #fbe6e4;
+    --shadow:     0 1px 2px rgba(20,24,28,.05), 0 1px 8px rgba(20,24,28,.04);
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ink:        #e8eaeb;
+      --ink-2:      #b9bcbe;
+      --muted:      #8d9195;
+      --faint:      #6b6f73;
+      --rule:       #3a3f43;
+      --rule-soft:  #2f3438;
+      --ground:     #212528;
+      --surface:    #292d31;
+      --spine:      #3f4448;
+      --accent:     #ff7350;
+      --accent-dim: #4a2419;
+      --ok:         #6cc070;
+      --warn:       #d0ae5e;
+      --stop:       #ff6a5c;
+      --ok-bg:      #23372a;
+      --warn-bg:    #3a3423;
+      --stop-bg:    #3d2523;
+      --shadow:     0 1px 2px rgba(0,0,0,.3), 0 1px 8px rgba(0,0,0,.2);
+    }
+  }
+  :root[data-theme="dark"] {
+    --ink:        #e8eaeb;
+    --ink-2:      #b9bcbe;
+    --muted:      #8d9195;
+    --faint:      #6b6f73;
+    --rule:       #3a3f43;
+    --rule-soft:  #2f3438;
+    --ground:     #212528;
+    --surface:    #292d31;
+    --spine:      #3f4448;
+    --accent:     #ff7350;
+    --accent-dim: #4a2419;
+    --ok:         #6cc070;
+    --warn:       #d0ae5e;
+    --stop:       #ff6a5c;
+    --ok-bg:      #23372a;
+    --warn-bg:    #3a3423;
+    --stop-bg:    #3d2523;
+    --shadow:     0 1px 2px rgba(0,0,0,.3), 0 1px 8px rgba(0,0,0,.2);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 940px; margin: 0 auto; padding: 32px 24px 80px; }
+
+  /* ---------- page head ---------- */
+  .pagehead { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 16px; justify-content: space-between; margin-bottom: 8px; }
+  h1 { font-size: 21px; font-weight: 650; margin: 0; letter-spacing: -.01em; }
+  .who { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-top: 3px; }
+  .who .name { font-size: 14px; color: var(--ink-2); }
+  .who .sep { color: var(--faint); }
+  .who .eid { font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
+
+  /* ---------- view switch (demo affordance) ---------- */
+  .switch { display: inline-flex; background: var(--surface); border: 1px solid var(--rule); border-radius: 7px; padding: 2px; box-shadow: var(--shadow); }
+  .switch button {
+    font: inherit; font-size: 12.5px; font-weight: 550;
+    padding: 5px 12px; border: 0; border-radius: 5px;
+    background: transparent; color: var(--muted); cursor: pointer;
+    transition: background .12s, color .12s;
+  }
+  .switch button[aria-pressed="true"] { background: var(--ink); color: var(--surface); }
+  .switch button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  .note {
+    margin: 18px 0 26px; padding: 9px 13px;
+    border-left: 2px solid var(--accent);
+    background: var(--surface);
+    border-radius: 0 5px 5px 0;
+    font-size: 12.5px; color: var(--ink-2);
+    box-shadow: var(--shadow);
+  }
+  .note b { font-weight: 600; color: var(--ink); }
+
+  /* ---------- period ---------- */
+  .period { margin-bottom: 30px; }
+  .period-head {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    padding-bottom: 9px; border-bottom: 1px solid var(--rule);
+    margin-bottom: 4px;
+  }
+  .period-type { font-size: 14.5px; font-weight: 640; letter-spacing: -.005em; }
+  .period-id { font-family: var(--mono); font-size: 12px; color: var(--muted); background: var(--rule-soft); padding: 1.5px 6px; border-radius: 4px; }
+  .period-span { font-size: 12.5px; color: var(--muted); font-variant-numeric: tabular-nums; margin-left: auto; }
+
+  .csr {
+    display: flex; align-items: center; gap: 7px;
+    font-size: 12px; color: var(--muted);
+    padding: 7px 0 3px 15px; margin-top: -2px;
+  }
+  .csr svg { flex: none; }
+
+  /* ---------- events ---------- */
+  .events { list-style: none; margin: 0; padding: 0; position: relative; }
+  .events::before {
+    content: ""; position: absolute; left: 15px; top: 12px; bottom: 12px;
+    width: 1px; background: var(--spine);
+  }
+
+  .ev { position: relative; display: grid; grid-template-columns: 32px 96px 1fr; align-items: baseline; gap: 0 14px; padding: 9px 0; }
+  .ev + .ev { border-top: 1px solid var(--rule-soft); }
+
+  .dot { position: relative; width: 32px; height: 15px; }
+  .dot::after {
+    content: ""; position: absolute; left: 11px; top: 5px;
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--spine); box-shadow: 0 0 0 3px var(--ground);
+  }
+  .ev.is-promo .dot::after { background: var(--accent); width: 9px; height: 9px; left: 10px; top: 4px; }
+  .ev.is-join  .dot::after,
+  .ev.is-exit  .dot::after { background: var(--ink-2); }
+
+  .when { font-size: 12.5px; color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+  .what { min-width: 0; }
+  .field { font-size: 12px; color: var(--muted); letter-spacing: .03em; text-transform: uppercase; margin-bottom: 2px; }
+  .change { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 14px; }
+  .from { color: var(--muted); text-decoration: line-through; text-decoration-color: var(--faint); text-decoration-thickness: 1px; }
+  .arrow { color: var(--faint); flex: none; }
+  .to { font-weight: 550; }
+  .single { font-size: 14px; font-weight: 550; }
+  .by { font-size: 12px; color: var(--faint); margin-top: 3px; }
+  .by .sysbadge {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .04em;
+    background: var(--rule-soft); color: var(--muted);
+    padding: 1px 5px; border-radius: 3px; margin-right: 5px;
+  }
+
+  .chip {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: 11.5px; font-weight: 600; letter-spacing: .02em;
+    padding: 2px 8px; border-radius: 20px; white-space: nowrap;
+  }
+  .chip.ok   { background: var(--ok-bg);   color: var(--ok); }
+  .chip.warn { background: var(--warn-bg); color: var(--warn); }
+  .chip.stop { background: var(--stop-bg); color: var(--stop); }
+  .chip.promo{ background: var(--accent-dim); color: var(--accent); }
+
+  .promo-detail {
+    margin-top: 7px; padding: 9px 12px;
+    background: var(--surface); border: 1px solid var(--rule);
+    border-radius: 6px; font-size: 12.5px; color: var(--ink-2);
+    display: flex; flex-wrap: wrap; gap: 4px 18px;
+  }
+  .promo-detail div { display: flex; gap: 6px; }
+  .promo-detail dt { color: var(--muted); margin: 0; }
+  .promo-detail dd { margin: 0; font-weight: 550; color: var(--ink); font-variant-numeric: tabular-nums; }
+
+  .leaver-detail { margin-top: 6px; font-size: 13px; color: var(--ink-2); }
+  .leaver-detail span { color: var(--muted); }
+
+  /* ---------- HR-only affordances ---------- */
+  .hr-only { display: none; }
+  body.is-hr .hr-only { display: revert; }
+  body.is-hr .by { display: block; }
+  body:not(.is-hr) .by { display: none; }
+
+  .sysrow { display: none; }
+  body.is-hr .sysrow { display: grid; }
+  body.is-hr .sysrow .what { opacity: .62; }
+
+  .foot { margin-top: 34px; padding-top: 14px; border-top: 1px solid var(--rule); font-size: 12px; color: var(--muted); }
+  .foot code { font-family: var(--mono); font-size: 11.5px; background: var(--rule-soft); padding: 1px 5px; border-radius: 3px; }
+
+  @media (max-width: 620px) {
+    .ev { grid-template-columns: 26px 1fr; }
+    .when { grid-column: 2; margin-bottom: 3px; }
+    .what { grid-column: 2; }
+    .events::before { left: 12px; }
+    .dot { width: 26px; }
+    .dot::after { left: 8px; }
+    .period-span { margin-left: 0; width: 100%; }
+  }
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+</style>
+
+<div class="wrap">
+
+  <div class="pagehead">
+    <div>
+      <h1>History</h1>
+      <div class="who">
+        <span class="name">Samina Iqbal</span>
+        <span class="sep">·</span>
+        <span class="eid">AE 10006</span>
+      </div>
+    </div>
+    <div class="switch" role="group" aria-label="Preview projection">
+      <button id="btn-emp" aria-pressed="true">Employee view</button>
+      <button id="btn-hr"  aria-pressed="false">HR view</button>
+    </div>
+  </div>
+
+  <p class="note" id="note"></p>
+
+  <!-- ============ PERIOD 1 ============ -->
+  <section class="period">
+    <div class="period-head">
+      <span class="period-type">Permanent</span>
+      <span class="period-id">EP 10006</span>
+      <span class="period-span">1 Jan 2024 — present</span>
+    </div>
+
+    <ul class="events">
+
+      <li class="ev is-exit">
+        <div class="dot"></div>
+        <div class="when">1 Aug 2026</div>
+        <div class="what">
+          <div class="field">Employee status</div>
+          <div class="change">
+            <span class="from">Active</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="chip warn">Marked leaver</span>
+          </div>
+          <div class="leaver-detail">
+            <span>Reason</span> Migration &nbsp;·&nbsp; <span>Final day</span> 31 Aug 2026
+          </div>
+          <div class="by">by amangi@wso2.com</div>
+        </div>
+      </li>
+
+      <li class="ev is-promo">
+        <div class="dot"></div>
+        <div class="when">3 Mar 2026</div>
+        <div class="what">
+          <div class="field">Promotion</div>
+          <div class="change">
+            <span class="from">Job Band 7</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="to">Job Band 8</span>
+            <span class="chip promo">Approved</span>
+          </div>
+          <dl class="promo-detail">
+            <div><dt>Cycle</dt><dd>2026 H1</dd></div>
+            <div><dt>Type</dt><dd>Normal</dd></div>
+            <div><dt>Role</dt><dd>Senior Software Engineer</dd></div>
+          </dl>
+        </div>
+      </li>
+
+      <li class="ev">
+        <div class="dot"></div>
+        <div class="when">12 Jun 2025</div>
+        <div class="what">
+          <div class="field">Team</div>
+          <div class="change">
+            <span class="from">Platform</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="to">Digital</span>
+          </div>
+          <div class="by">by amangi@wso2.com</div>
+        </div>
+      </li>
+
+      <li class="ev">
+        <div class="dot"></div>
+        <div class="when">12 Jun 2025</div>
+        <div class="what">
+          <div class="field">Sub-team</div>
+          <div class="change">
+            <span class="from">Integration</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="to">Internal Apps</span>
+          </div>
+          <div class="by">by amangi@wso2.com</div>
+        </div>
+      </li>
+
+      <li class="ev">
+        <div class="dot"></div>
+        <div class="when">4 Feb 2025</div>
+        <div class="what">
+          <div class="field">Reporting to</div>
+          <div class="change">
+            <span class="from">uday@wso2.com</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="to">chanuka@wso2.com</span>
+          </div>
+          <div class="by">by inthira@wso2.com</div>
+        </div>
+      </li>
+
+      <li class="ev sysrow">
+        <div class="dot"></div>
+        <div class="when">10 Jun 2024</div>
+        <div class="what">
+          <div class="field">Record migrated</div>
+          <div class="change"><span class="single">No field changes</span></div>
+          <div class="by"><span class="sysbadge">SYSTEM</span>MIGRATION · 5 runs collapsed</div>
+        </div>
+      </li>
+
+      <li class="ev is-join">
+        <div class="dot"></div>
+        <div class="when">1 Jan 2024</div>
+        <div class="what">
+          <div class="field">Joined</div>
+          <div class="change">
+            <span class="single">Software Engineer II</span>
+            <span class="chip ok">Permanent</span>
+          </div>
+          <div class="by">by MIGRATION</div>
+        </div>
+      </li>
+
+    </ul>
+  </section>
+
+  <!-- ============ PERIOD 2 ============ -->
+  <section class="period">
+    <div class="period-head">
+      <span class="period-type">Internship</span>
+      <span class="period-id">IN 0456</span>
+      <span class="period-span">3 Jun 2023 — 1 Dec 2023</span>
+    </div>
+
+    <div class="csr">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1"/></svg>
+      Continuous service — linked to Permanent · EP 10006
+    </div>
+
+    <ul class="events">
+      <li class="ev is-exit">
+        <div class="dot"></div>
+        <div class="when">1 Dec 2023</div>
+        <div class="what">
+          <div class="field">Employee status</div>
+          <div class="change">
+            <span class="from">Active</span>
+            <span class="arrow" aria-hidden="true">→</span>
+            <span class="chip stop">Left</span>
+          </div>
+          <div class="by">by inthira@wso2.com</div>
+        </div>
+      </li>
+
+      <li class="ev is-join">
+        <div class="dot"></div>
+        <div class="when">3 Jun 2023</div>
+        <div class="what">
+          <div class="field">Joined</div>
+          <div class="change">
+            <span class="single">Software Engineer Intern</span>
+            <span class="chip ok">Internship</span>
+          </div>
+          <div class="by">by inthira@wso2.com</div>
+        </div>
+      </li>
+    </ul>
+  </section>
+
+  <p class="foot">
+    Mock data. Promotions are read from the HRIS database where
+    <code>status = APPROVED</code> and <code>cycle = END</code>.
+  </p>
+
+</div>
+
+<script>
+  const body  = document.body;
+  const bEmp  = document.getElementById("btn-emp");
+  const bHr   = document.getElementById("btn-hr");
+  const note  = document.getElementById("note");
+
+  const COPY = {
+    emp: "<b>Employee view</b> — what a person sees on their own profile. No editor attribution, and system/migration rows are filtered out.",
+    hr:  "<b>HR view</b> — adds <b>who</b> made each change, and surfaces collapsed system rows so the record is complete."
+  };
+
+  function set(isHr) {
+    body.classList.toggle("is-hr", isHr);
+    bHr.setAttribute("aria-pressed", String(isHr));
+    bEmp.setAttribute("aria-pressed", String(!isHr));
+    note.innerHTML = isHr ? COPY.hr : COPY.emp;
+  }
+  bEmp.addEventListener("click", () => set(false));
+  bHr.addEventListener("click",  () => set(true));
+  set(false);
+</script>

--- a/docs/specs/assets/2026-08-11-employee-history-mockup.html
+++ b/docs/specs/assets/2026-08-11-employee-history-mockup.html
@@ -1,3 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
 <title>Employee History — People App</title>
 
 <style>


### PR DESCRIPTION
## Overview

There was no way to see how an employee's record had changed over time. The data existed — four audit tables capture every insert and update as a full JSON snapshot — but nothing read it. Answering "when did this person move to Digital?" or "when were they last promoted?" meant querying the audit table by hand.

This adds a **History** section to the employee profile, for two audiences: People Ops reviewing a record, and the employee viewing their own.

## What it shows

A timeline grouped by employment period, newest first, with each change rendered as `old → new`. Above it, tabs switch between views:

```
All 10   Employment 6   Personal Info 3   Promotions 1
─────────────────────────────────────────────────────
```

- **Employment** — organisation moves, designation, manager, status, dates, and the rest of the 19 tracked employee fields
- **Personal Info** — all 17 `personal_info` columns except the generated `full_name`
- **Promotions** — from the HRIS database, showing the job band change, cycle and type

Periods joined by a relocation are drawn with a connector between them, so a rehired employee reads as one continuous career rather than unrelated records.

## Design decisions

**Identity is the person, not the employment row.** `work_email` is NOT NULL but *not* unique, and a rehired employee gets a new `employee` row that reuses it. Identity resolves by walking the `continuous_service_record` chain, unioned with `personal_info_id` matches. That matters in practice: a real record here has three employments whose NIC was recorded three ways, so they hold three different `personal_info_id` values and no single-column rule would have found them all.

**Diffing happens at read time.** The audit tables hold whole snapshots rather than deltas, so events are derived by comparing consecutive rows. No new tables, no migration, and it works retroactively on existing data. Three rules keep it correct: an INSERT is a baseline rather than a change, diffs are keyed per employment record so a rehire's interleaved rows never compare against each other, and rows are only compared within their own source table.

**Noise is filtered.** Only tracked fields produce events. Real data had roughly 150 real changes among 5000 audit rows — the rest were migration re-writes touching only `updated_on` and the avatar URL.

**One engine, two projections, filtered server-side.** Employees see their own history without editor attribution or system rows. ADMIN, and a LEAD viewing a current subordinate, see both. The client never receives data it may not show.

**Promotions are attributed by their created date**, not the promoted date — HRIS frequently leaves the latter null, whereas a request is always raised while the employee is employed, so its created date falls inside exactly one period.

## Also in this PR

**Two pre-existing bugs**, found while testing against real data:

- **Continuous service date walked only one link.** An employee with three linked employments reported the middle one's start date, understating service by years. This affected the employee detail page, My Team and the CSV export — not just the new timeline.
- **CSV exports omitted the external designation column.** The picker offered it while the backend allowlist did not contain it, so selecting it produced a file silently missing that column.

**One UX change to an existing section:** Personal Information no longer opens expanded. This PR adds a third section to the profile, and leaving two open plus a new one made the default page long. General Information stays expanded; Personal Information and History are collapsed. The personal-info fetch is unchanged and still runs on mount, so opening the section shows data immediately.

## New configuration

Requires a `[people.promotion.promotionDbConfig]` block for the HRIS database. `Config.toml.local` carries empty placeholders and a note that `maxConnectionLifeTime` must stay below the HRIS server's `wait_timeout` — the pool otherwise hands out a closed connection and queries fail with SQL state 08003.

## Verification

Verified against a real database and the live HRIS instance: promotions render with the correct job bands and cycle; a rehired employee's three employments appear as one history with relocation connectors; org changes resolve to names rather than ids; the continuous service date resolves to the true chain origin; and a personal-info edit appears under the Personal Info tab.

`bal build` succeeds, `tsc --noEmit` passes with zero errors, ESLint is clean, and the existing 15 webapp tests pass.

**Not covered:** the backend has no automated tests, so backend verification is manual throughout. The authorization tiers — the employee projection, lead-viewing-subordinate, and the 403 path — are implemented and reviewed but have not been exercised with different logged-in roles.

## Review status

All 20 review findings have been replied to; 11 threads are resolved. Four remain open deliberately, being decisions rather than defects:

- `employee_additional_managers_audit` is fetched but produces no events. The primary manager is already tracked via `manager_email`; additional-manager history needs a stable relationship key first.
- The continuous-service fix uses a correlated recursive CTE evaluated per row. A set-based form would be cheaper on the list and export paths, but the shape should not be traded without measurement.
- Whether the implementation plan belongs in the repo alongside the design doc.

One finding is worth calling out because it was a genuine access-control hole: `manager_email` is never cleared when an employment ends, so a former lead could quote a stale employee ID, pass `isSubordinateOfLead`, and receive that person's current employment with attribution. Fixed in `cfa92d53` by requiring the requested row to be the person's current employment.

## Tracking

Feature #1019, tasks #1020–#1025, under epic #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an employee History view with a filterable timeline of employment, profile changes, status updates, relocations, and promotions.
  * History now groups events across rehires and continuous employment periods.
  * Added approved promotion details from HRIS, with clear availability status if promotion data cannot be retrieved.
  * Added access-aware history views for employees, managers, and administrators.
* **Documentation**
  * Added employee-history design, implementation, and interactive mockup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->